### PR TITLE
Add support of password authentication (AUTH)

### DIFF
--- a/hircluster.h
+++ b/hircluster.h
@@ -21,6 +21,8 @@
 #define REDIS_ROLE_MASTER 1
 #define REDIS_ROLE_SLAVE 2
 
+#define CONFIG_AUTHPASS_MAX_LEN 512 // Defined in Redis as max characters
+
 #define HIRCLUSTER_FLAG_NULL 0x0
 /* The flag to decide whether add slave node in
  * redisClusterContext->nodes. This is set in the
@@ -99,6 +101,8 @@ typedef struct redisClusterContext {
     int need_update_route;
     int64_t update_route_time;
 
+    char password[CONFIG_AUTHPASS_MAX_LEN + 1]; // Include a null terminator
+
 #ifdef SSL_SUPPORT
     redisSSLContext *ssl;
 #endif
@@ -118,6 +122,8 @@ int redisClusterSetOptionAddNode(redisClusterContext *cc, const char *addr);
 int redisClusterSetOptionAddNodes(redisClusterContext *cc, const char *addrs);
 int redisClusterSetOptionConnectBlock(redisClusterContext *cc);
 int redisClusterSetOptionConnectNonBlock(redisClusterContext *cc);
+int redisClusterSetOptionPassword(redisClusterContext *cc,
+                                  const char *password);
 int redisClusterSetOptionParseSlaves(redisClusterContext *cc);
 int redisClusterSetOptionParseOpenSlots(redisClusterContext *cc);
 int redisClusterSetOptionRouteUseSlots(redisClusterContext *cc);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,9 @@ else()
   add_compile_options(-Wall -Wextra -pedantic -Werror)
 endif()
 
+# Debug mode for tests
+set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+
 # Executable: IPv4
 add_executable(example_ipv4 main.c)
 target_link_libraries(example_ipv4 hiredis_cluster hiredis ${SSL_LIBRARY})
@@ -43,6 +46,12 @@ add_test(NAME example_async COMMAND "$<TARGET_FILE:example_async>")
 add_executable(ct_commands ct_commands.c)
 target_link_libraries(ct_commands hiredis_cluster hiredis ${SSL_LIBRARY})
 add_test(NAME ct_commands COMMAND "$<TARGET_FILE:ct_commands>")
+set_tests_properties(ct_commands PROPERTIES LABELS "CT")
+
+add_executable(ct_connection ct_connection.c)
+target_link_libraries(ct_connection hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+add_test(NAME ct_connection COMMAND "$<TARGET_FILE:ct_connection>")
+set_tests_properties(ct_connection PROPERTIES LABELS "CT")
 
 if(ENABLE_SSL)
   # Executable: tls

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -1,0 +1,176 @@
+#include "adapters/libevent.h"
+#include "hircluster.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CLUSTER_NODE_WITH_PASSWORD "127.0.0.1:30001"
+#define CLUSTER_PASSWORD "secretword"
+
+// Connecting to a password protected cluster and
+// providing a correct password.
+void test_password_ok() {
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
+    redisClusterSetOptionPassword(cc, CLUSTER_PASSWORD);
+    redisClusterConnect2(cc);
+
+    assert(cc->err == 0);
+
+    // Test connection
+    redisReply *reply;
+    reply = (redisReply *)redisClusterCommand(cc, "SET key1 Hello");
+    assert(reply);
+    assert(strcmp(reply->str, "OK") == 0);
+    freeReplyObject(reply);
+
+    redisClusterFree(cc);
+}
+
+// Connecting to a password protected cluster and
+// providing wrong password.
+void test_password_wrong() {
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
+    redisClusterSetOptionPassword(cc, "wrongpass");
+    redisClusterConnect2(cc);
+
+    assert(cc->err == REDIS_ERR_OTHER);
+    assert(strncmp(cc->errstr, "WRONGPASS", 9) == 0);
+
+    redisClusterFree(cc);
+}
+
+// Connecting to a password protected cluster and
+// not providing any password.
+void test_password_missing() {
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
+    // A password is not configured..
+    redisClusterConnect2(cc);
+
+    assert(cc->err == REDIS_ERR_OTHER);
+    assert(strncmp(cc->errstr, "NOAUTH", 6) == 0);
+
+    redisClusterFree(cc);
+}
+
+//------------------------------------------------------------------------------
+// Async API
+//------------------------------------------------------------------------------
+
+void callbackExpectOk(const redisAsyncContext *ac, int status) {
+    UNUSED(ac);
+    assert(status == REDIS_OK);
+}
+
+void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
+    UNUSED(r);
+    UNUSED(privdata);
+    redisReply *reply = (redisReply *)r;
+    assert(reply != NULL);
+    assert(strcmp(reply->str, "OK") == 0);
+    redisClusterAsyncDisconnect(cc);
+}
+
+// Connecting to a password protected cluster using
+// the async API, providing correct password.
+void test_async_password_ok() {
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+    redisClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    redisClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_WITH_PASSWORD);
+    redisClusterSetOptionPassword(acc->cc, CLUSTER_PASSWORD);
+    redisClusterConnect2(acc->cc);
+
+    assert(acc->err == 0);
+
+    struct event_base *base = event_base_new();
+    redisClusterLibeventAttach(acc, base);
+
+    // Test connection
+    int status = redisClusterAsyncCommand(acc, commandCallback,
+                                          (char *)"THE_ID", "SET key1 Hello");
+    assert(status == REDIS_OK);
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+}
+
+// Connecting to a password protected cluster using
+// the async API, providing wrong password.
+void test_async_password_wrong() {
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+    redisClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    redisClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_WITH_PASSWORD);
+    redisClusterSetOptionPassword(acc->cc, "wrongpass");
+    redisClusterConnect2(acc->cc);
+
+    assert(acc->err == 0);
+
+    struct event_base *base = event_base_new();
+    redisClusterLibeventAttach(acc, base);
+
+    // Test connection
+    int status = redisClusterAsyncCommand(acc, commandCallback,
+                                          (char *)"THE_ID", "SET key1 Hello");
+    assert(status == REDIS_ERR);
+    assert(acc->err == REDIS_ERR_OTHER);
+    assert(strcmp(acc->errstr, "node get by table error") == 0);
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+}
+
+// Connecting to a password protected cluster using
+// the async API, not providing a password.
+void test_async_password_missing() {
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+    redisClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    redisClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_WITH_PASSWORD);
+    // Password not configured
+    redisClusterConnect2(acc->cc);
+
+    assert(acc->err == 0);
+
+    struct event_base *base = event_base_new();
+    redisClusterLibeventAttach(acc, base);
+
+    // Test connection
+    int status = redisClusterAsyncCommand(acc, commandCallback,
+                                          (char *)"THE_ID", "SET key1 Hello");
+    assert(status == REDIS_ERR);
+    assert(acc->err == REDIS_ERR_OTHER);
+    assert(strcmp(acc->errstr, "node get by table error") == 0);
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+}
+
+int main() {
+
+    test_password_ok();
+    test_password_wrong();
+    test_password_missing();
+
+    test_async_password_ok();
+    test_async_password_wrong();
+    test_async_password_missing();
+
+    return 0;
+}


### PR DESCRIPTION
When a password is configured it will be sent right
after a connection to a Redis instance is setup,
via the AUTH command.

Added API:
    redisClusterSetOptionPassword(cc, "password");