### PR TITLE
Initial support of transactions

### DIFF
--- a/command.c
+++ b/command.c
@@ -15,6 +15,9 @@ static int redis_argz(struct cmd *r) {
     switch (r->type) {
     case CMD_REQ_REDIS_PING:
     case CMD_REQ_REDIS_QUIT:
+    case CMD_REQ_REDIS_MULTI:
+    case CMD_REQ_REDIS_EXEC:
+    case CMD_REQ_REDIS_DISCARD:
         return 1;
 
     default:
@@ -595,6 +598,11 @@ void redis_parse_cmd(struct cmd *r) {
                     break;
                 }
 
+                if (str4icmp(m, 'e', 'x', 'e', 'c')) {
+                    r->type = CMD_REQ_REDIS_EXEC;
+                    break;
+                }
+
                 break;
 
             case 5:
@@ -685,6 +693,11 @@ void redis_parse_cmd(struct cmd *r) {
 
                 if (str5icmp(m, 'p', 'f', 'a', 'd', 'd')) {
                     r->type = CMD_REQ_REDIS_PFADD;
+                    break;
+                }
+
+                if (str5icmp(m, 'm', 'u', 'l', 't', 'i')) {
+                    r->type = CMD_REQ_REDIS_MULTI;
                     break;
                 }
 
@@ -846,6 +859,11 @@ void redis_parse_cmd(struct cmd *r) {
 
                 if (str7icmp(m, 'p', 'f', 'm', 'e', 'r', 'g', 'e')) {
                     r->type = CMD_REQ_REDIS_PFMERGE;
+                    break;
+                }
+
+                if (str7icmp(m, 'd', 'i', 's', 'c', 'a', 'r', 'd')) {
+                    r->type = CMD_REQ_REDIS_DISCARD;
                     break;
                 }
 

--- a/command.h
+++ b/command.h
@@ -120,6 +120,9 @@ typedef enum cmd_parse_result {
     ACTION(REQ_REDIS_PING) /* redis requests - ping/quit */                    \
     ACTION(REQ_REDIS_QUIT)                                                     \
     ACTION(REQ_REDIS_AUTH)                                                     \
+    ACTION(REQ_REDIS_MULTI)                                                    \
+    ACTION(REQ_REDIS_EXEC)                                                     \
+    ACTION(REQ_REDIS_DISCARD)                                                  \
     ACTION(RSP_REDIS_STATUS) /* redis response */                              \
     ACTION(RSP_REDIS_ERROR)                                                    \
     ACTION(RSP_REDIS_INTEGER)                                                  \

--- a/hircluster.h
+++ b/hircluster.h
@@ -106,6 +106,7 @@ typedef struct redisClusterContext {
 #ifdef SSL_SUPPORT
     redisSSLContext *ssl;
 #endif
+    int transaction_slot;
 
 } redisClusterContext;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,11 @@ if(ENABLE_IPV6_TESTS)
   set_tests_properties(ct_connection_ipv6 PROPERTIES LABELS "CT")
 endif()
 
+add_executable(ct_transaction ct_transaction.c)
+target_link_libraries(ct_transaction hiredis_cluster hiredis ${SSL_LIBRARY})
+add_test(NAME ct_transaction COMMAND "$<TARGET_FILE:ct_transaction>")
+set_tests_properties(ct_transaction PROPERTIES LABELS "CT")
+
 if(ENABLE_SSL)
   # Executable: tls
   add_executable(example_tls main_tls.c)

--- a/tests/ct_transaction.c
+++ b/tests/ct_transaction.c
@@ -1,0 +1,134 @@
+#include "hircluster.h"
+#include "test_utils.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CLUSTER_NODE "127.0.0.1:7000"
+
+// Test of transactions in using the pipelined sync api
+void test_pipelined_transaction() {
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+
+    int status;
+    status = redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    status = redisClusterConnect2(cc);
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    status = redisClusterAppendCommand(cc, "MULTI");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "SET bar five");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "SET foo five"); // New slot..
+    ASSERT_MSG(status == REDIS_ERR, cc->errstr);            // ..gives REDIS_ERR
+    status = redisClusterAppendCommand(cc, "GET bar");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "EXEC");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    redisReply *reply;
+    redisClusterGetReply(cc, (void *)&reply); // reply for: MULTI
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: SET
+    CHECK_REPLY_QUEUED(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: GET
+    CHECK_REPLY_QUEUED(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: EXEC
+    CHECK_REPLY_ARRAY(cc, reply, 2);
+    CHECK_REPLY_OK(cc, reply->element[0]);
+    CHECK_REPLY_STR(cc, reply->element[1], "five");
+    freeReplyObject(reply);
+
+    redisClusterFree(cc);
+}
+
+// Test of discarding a transaction
+void test_discarded_pipelined_transaction() {
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+
+    int status;
+    status = redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    status = redisClusterConnect2(cc);
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    status = redisClusterAppendCommand(cc, "SET foo 55");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "MULTI");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "INCR foo");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "DISCARD");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "GET foo");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "MULTI");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "INCR foo");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "EXEC");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommand(cc, "GET foo");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    redisReply *reply;
+    redisClusterGetReply(cc, (void *)&reply); // reply for: SET
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: MULTI
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: INCR
+    CHECK_REPLY_QUEUED(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: DISCARD
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: GET
+    CHECK_REPLY_STR(cc, reply, "55");
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: MULTI
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: INCR
+    CHECK_REPLY_QUEUED(cc, reply);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: EXEC
+    CHECK_REPLY_ARRAY(cc, reply, 1);
+    CHECK_REPLY_INT(cc, reply->element[0], 56); // INCR
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply); // reply for: GET
+    CHECK_REPLY_STR(cc, reply, "56");
+    freeReplyObject(reply);
+
+    redisClusterFree(cc);
+}
+
+int main() {
+
+    test_pipelined_transaction();
+    test_discarded_pipelined_transaction();
+
+    return 0;
+}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -8,8 +8,13 @@
     }
 
 #define CHECK_REPLY(_ctx, _reply)                                              \
-    if (!(_reply)) {                                                           \
-        ASSERT_MSG(_reply, _ctx->errstr);                                      \
+    if ((_reply) == NULL) {                                                    \
+        fprintf(stderr, "ERROR: reply=NULL  =>  ");                            \
+        if ((_ctx) != NULL) {                                                  \
+            ASSERT_MSG(_reply, _ctx->errstr);                                  \
+        } else {                                                               \
+            ASSERT_MSG(_reply, "context is NULL");                             \
+        }                                                                      \
     }
 
 #define CHECK_REPLY_TYPE(_reply, _type)                                        \
@@ -20,6 +25,13 @@
         CHECK_REPLY(_ctx, _reply);                                             \
         CHECK_REPLY_TYPE(_reply, REDIS_REPLY_STATUS);                          \
         ASSERT_MSG((strcmp(_reply->str, "OK") == 0), _ctx->errstr);            \
+    }
+
+#define CHECK_REPLY_QUEUED(_ctx, _reply)                                       \
+    {                                                                          \
+        CHECK_REPLY(_ctx, _reply);                                             \
+        CHECK_REPLY_TYPE(_reply, REDIS_REPLY_STATUS);                          \
+        ASSERT_MSG((strcmp(_reply->str, "QUEUED") == 0), _ctx->errstr);        \
     }
 
 #define CHECK_REPLY_INT(_ctx, _reply, _value)                                  \


### PR DESCRIPTION
Handles MULTI, EXEC and DISCARD messages in the pipeline API
using `redisClusterAppendCommand()`

What the implementation does is that when a MULTI command is received it is not sent directly.
Instead its saved in a queue as normally done as well, but now also keeping its command string that will be sent later.
When the next command is received its slot is extracted, and used for the saved MULTI command as well.
The MULTI command is now sent to the correct node before the first command in the transaction.
When EXEC is sent this finishes the transaction state, and will receive the array of all responses.

Only supports transactions to a single slot
Only supports the pipeline API currently
Support for async and single sync api to be added