### PR TITLE
Add a very basic fake Redis Cluster for test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: RelWithDebInfo
 
 jobs:
   checkers:
@@ -45,7 +45,7 @@ jobs:
       working-directory: build
       run: cmake --build . --config $BUILD_TYPE
 
-    # - name: Test
-    #   working-directory: build
-    #   shell: bash
-    #   run: ctest -C $BUILD_TYPE
+    - name: Test (using fake cluster)
+      shell: bash
+      working-directory: build
+      run: ctest -C $BUILD_TYPE -L CT-FAKE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,10 @@ if(ENABLE_SSL)
 endif()
 
 
-find_library(EVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+find_library(LIBEVENT_LIB REQUIRED event HINTS /usr/lib/x86_64-linux-gnu)
+find_library(LIBEVENT_PTHREAD_LIB REQUIRED event_pthreads HINTS /usr/lib/x86_64-linux-gnu)
 
 if(MSVC)
   # MS Visual: Suppress warnings
@@ -40,7 +43,7 @@ add_test(NAME example_ipv6 COMMAND "$<TARGET_FILE:example_ipv6>")
 
 # Executable: async
 add_executable(example_async main_async.c)
-target_link_libraries(example_async hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(example_async hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIB})
 add_test(NAME example_async COMMAND "$<TARGET_FILE:example_async>")
 
 add_executable(ct_commands ct_commands.c)
@@ -49,14 +52,20 @@ add_test(NAME ct_commands COMMAND "$<TARGET_FILE:ct_commands>")
 set_tests_properties(ct_commands PROPERTIES LABELS "CT")
 
 add_executable(ct_connection ct_connection.c)
-target_link_libraries(ct_connection hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_connection hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIB})
 add_test(NAME ct_connection COMMAND "$<TARGET_FILE:ct_connection>")
 set_tests_properties(ct_connection PROPERTIES LABELS "CT")
 
 add_executable(ct_pipeline ct_pipeline.c)
-target_link_libraries(ct_pipeline hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_pipeline hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIB})
 add_test(NAME ct_pipeline COMMAND "$<TARGET_FILE:ct_pipeline>")
 set_tests_properties(ct_pipeline PROPERTIES LABELS "CT")
+
+add_executable(ct_fakecluster ct_fakecluster.c fakecluster.c)
+target_link_libraries(ct_fakecluster PRIVATE
+  hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIB} ${LIBEVENT_PTHREAD_LIB} Threads::Threads)
+add_test(NAME ct_fakecluster COMMAND "$<TARGET_FILE:ct_fakecluster>")
+set_tests_properties(ct_fakecluster PROPERTIES LABELS "CT-FAKE")
 
 if(ENABLE_SSL)
   # Executable: tls
@@ -67,7 +76,7 @@ if(ENABLE_SSL)
 
   # Executable: async tls
   add_executable(example_async_tls main_async_tls.c)
-  target_link_libraries(example_async_tls hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+  target_link_libraries(example_async_tls hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIB})
   add_dependencies(example_async_tls generate_tls_configs)
   add_test(NAME example_async_tls COMMAND "$<TARGET_FILE:example_async_tls>")
 endif()

--- a/tests/ct_fakecluster.c
+++ b/tests/ct_fakecluster.c
@@ -1,0 +1,65 @@
+#include "fakecluster.h"
+#include "hircluster.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FAKE_CLUSTER_FIRST_PORT 4455
+#define FAKE_CLUSTER_NUM_OF_NODES 6
+#define FAKE_CLUSTER_INITNODE "127.0.0.1:4455"
+
+#define ASSERT_MSG(_x, _msg)                                                   \
+    if (!(_x)) {                                                               \
+        fprintf(stderr, "ERROR: %s\n", _msg);                                  \
+        assert(_x);                                                            \
+    }
+
+// Test of a cluster that suddenly is inaccessible
+void test_cluster_stops() {
+    int res;
+
+    // Start a cluster
+    fakecluster_start(FAKE_CLUSTER_FIRST_PORT, FAKE_CLUSTER_NUM_OF_NODES);
+
+    // Setup client
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    res = redisClusterSetOptionAddNodes(cc, FAKE_CLUSTER_INITNODE);
+    ASSERT_MSG(res == REDIS_OK, cc->errstr);
+
+    struct timeval timeout = {0, 500000};
+    res = redisClusterSetOptionConnectTimeout(cc, timeout);
+    ASSERT_MSG(res == REDIS_OK, cc->errstr);
+    res = redisClusterSetOptionTimeout(cc, timeout);
+    ASSERT_MSG(res == REDIS_OK, cc->errstr);
+    res = redisClusterSetOptionMaxRedirect(cc, 3);
+    ASSERT_MSG(res == REDIS_OK, cc->errstr);
+
+    // Perform initial connect to get cluster info
+    res = redisClusterConnect2(cc);
+    ASSERT_MSG(res == REDIS_OK, cc->errstr);
+
+    // Request towards running cluster
+    redisReply *reply;
+    reply = (redisReply *)redisClusterCommand(cc, "SET key HelloWorld");
+    assert(reply);
+    assert(strcmp(reply->str, "OK") == 0);
+    freeReplyObject(reply);
+
+    // Stop cluster
+    fakecluster_stop();
+
+    // Request towards stopped cluster
+    reply = (redisReply *)redisClusterCommand(cc, "SET key HelloWorld");
+    assert(reply == NULL);
+
+    redisClusterFree(cc);
+}
+
+int main() {
+
+    test_cluster_stops();
+
+    return 0;
+}

--- a/tests/fakecluster.c
+++ b/tests/fakecluster.c
@@ -1,0 +1,194 @@
+#include <arpa/inet.h>
+#include <assert.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
+#include <event2/event.h>
+#include <event2/listener.h>
+#include <event2/thread.h>
+#include <event2/util.h>
+
+#include "adlist.h"
+#include "hiarray.h"
+
+#define UNUSED(x) (void)(x)
+
+pthread_t tid = 0;
+struct event_base *base;
+struct hiarray *listeners;
+hilist *bufferevents;
+
+static struct evconnlistener *create_listener(int port);
+static void *thread_func(void *arg);
+static void listener_cb(struct evconnlistener *, evutil_socket_t,
+                        struct sockaddr *, int socklen, void *);
+static void conn_event_cb(struct bufferevent *, short, void *);
+static void conn_read_cb(struct bufferevent *, void *);
+
+// Start listening for connections on given port
+void fakecluster_start(int first_port, int number_of_nodes) {
+    // Due to CLUSTER NODES static response
+    assert(first_port == 4455);
+    assert(number_of_nodes == 6);
+
+    listeners = hiarray_create(1, sizeof(struct evconnlistener *));
+    bufferevents = listCreate();
+
+    int ret;
+    ret = evthread_use_pthreads();
+    assert(ret == 0);
+
+    base = event_base_new();
+    assert(base);
+
+    ret = pthread_create(&tid, NULL, thread_func, NULL);
+    assert(ret == 0);
+
+    int port = first_port;
+    for (int i = 0; i < number_of_nodes; ++i) {
+        struct evconnlistener **l = hiarray_push(listeners);
+        assert(l);
+        *l = create_listener(port + i);
+    }
+}
+
+// Close sockets and terminate eventloop
+void fakecluster_stop() {
+    event_base_loopbreak(base);
+
+    pthread_join(tid, NULL);
+
+    // Cleanup libevent data
+
+    listIter li;
+    listRewind(bufferevents, &li);
+
+    listNode *ln;
+    while ((ln = listNext(&li))) {
+        bufferevent_free((struct bufferevent *)ln->value);
+        listDelNode(bufferevents, ln);
+    }
+    listRelease(bufferevents);
+
+    while (hiarray_n(listeners)) {
+        struct evconnlistener **l = hiarray_pop(listeners);
+        evconnlistener_free(*l);
+    }
+    hiarray_destroy(listeners);
+
+    event_base_free(base);
+    libevent_global_shutdown();
+}
+
+// Register a server socket
+static struct evconnlistener *create_listener(int port) {
+    struct evconnlistener *listener;
+
+    printf("Start listening on: :%d\n", port);
+    struct sockaddr_in sin = {0};
+    sin.sin_family = AF_INET;
+    sin.sin_addr.s_addr = htonl(INADDR_ANY);
+    sin.sin_port = htons(port);
+    listener =
+        evconnlistener_new_bind(base, listener_cb, (void *)base,
+                                LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, -1,
+                                (struct sockaddr *)&sin, sizeof(sin));
+    assert(listener);
+    return listener;
+}
+
+// Thread that runs the eventloop
+static void *thread_func(void *arg) {
+    UNUSED(arg);
+    event_base_loop(base, EVLOOP_NO_EXIT_ON_EMPTY);
+    return NULL;
+}
+
+// Handle a connecting client
+static void listener_cb(struct evconnlistener *listener, evutil_socket_t fd,
+                        struct sockaddr *sa, int socklen, void *user_data) {
+    UNUSED(listener);
+    UNUSED(socklen);
+    UNUSED(user_data);
+    struct event_base *base = user_data;
+    struct bufferevent *bev;
+
+    struct sockaddr_in *addr_in = (struct sockaddr_in *)sa;
+    printf("Accepting %s:%d\n", inet_ntoa(addr_in->sin_addr),
+           addr_in->sin_port); // IPv4 only!
+
+    bev = bufferevent_socket_new(base, fd,
+                                 BEV_OPT_CLOSE_ON_FREE | BEV_OPT_THREADSAFE);
+    assert(bev);
+
+    bufferevent_setcb(bev, conn_read_cb, NULL, conn_event_cb, NULL);
+    bufferevent_enable(bev, EV_READ | EV_WRITE);
+
+    // Store bufferevent to be able to close connections
+    listAddNodeTail(bufferevents, bev);
+}
+
+// Handle connection error events
+static void conn_event_cb(struct bufferevent *bev, short events,
+                          void *user_data) {
+    UNUSED(user_data);
+    if (events & BEV_EVENT_EOF) {
+        printf("Connection closed.\n");
+    } else if (events & BEV_EVENT_ERROR) {
+        printf("Error: %s\n", strerror(errno));
+    }
+
+    // Remove closed bufferevent from book-keeping
+    listNode *ln = listSearchKey(bufferevents, bev);
+    assert(ln);
+    listDelNode(bufferevents, ln);
+
+    bufferevent_free(bev);
+}
+
+// Handle data sent by a client
+static void conn_read_cb(struct bufferevent *bev, void *user_data) {
+    UNUSED(user_data);
+
+    struct evbuffer *input = bufferevent_get_input(bev);
+
+    size_t len = evbuffer_get_length(input);
+    char *data = (char *)malloc(len);
+    evbuffer_copyout(input, data, len);
+
+    // Very-very simple parsing, needs to be improved!
+    if (memcmp(data, "*2\r\n$7\r\nCLUSTER\r\n$5\r\nNODES\r\n", 28) == 0) {
+        // CLUSTER NODES
+
+        // clang-format off
+        char *cluster_nodes =
+        "5cd86adfc69683c4a495d26276e68e1b111fc467 127.0.0.1:4455@40001 myself,master - 0 1605808574000 1 connected 0-5460\n"
+        "c1894bfdb935d811207ff6e2a2c53f3a5c31cc1e 127.0.0.1:4460@40002 master - 0 1605808573000 2 connected 5461-10922\n"
+        "f0ee4b54ed31850840574452500591e3ea09de21 127.0.0.1:4459@40003 master - 0 1605808573891 3 connected 10923-16383\n"
+        "33ca628c512a5159f168a210ec2c1efef3e0bd5c 127.0.0.1:4456@40005 slave f0ee4b54ed31850840574452500591e3ea09de21 0 1605808573391 5 connected\n"
+        "985075cec85e5ced0df9d0a70c24674f88966541 127.0.0.1:4457@40006 slave 5cd86adfc69683c4a495d26276e68e1b111fc467 0 1605808574393 6 connected\n"
+        "ec43d216912ea76438d0db6f56e077d53d32d33b 127.0.0.1:4458@40004 slave c1894bfdb935d811207ff6e2a2c53f3a5c31cc1e 0 1605808573591 4 connected\n";
+        // clang-format on
+
+        char msg[800];
+        int n = sprintf(msg, "$%ld\r\n%s\r\n", strlen(cluster_nodes),
+                        cluster_nodes);
+        assert(n);
+        bufferevent_write(bev, msg, strlen(msg));
+    } else if (memcmp(data, "*3\r\n$3\r\nSET\r\n", 13) == 0) {
+        // SET
+        char *msg = "+OK\r\n";
+        bufferevent_write(bev, msg, strlen(msg));
+    } else {
+        printf("UNKNOWN COMMAND: '%s'", data);
+        char *msg = "-ERR unknown command\r\n";
+        bufferevent_write(bev, msg, strlen(msg));
+    }
+
+    free(data);
+}

--- a/tests/fakecluster.h
+++ b/tests/fakecluster.h
@@ -1,0 +1,7 @@
+#ifndef __FAKECLUSTER_H__
+#define __FAKECLUSTER_H__
+
+void fakecluster_start(int start_port, int number_of_nodes);
+void fakecluster_stop();
+
+#endif


### PR DESCRIPTION
This is a very rough initial version which needs a lot of love.
Its possible to setup a 6 node cluster on fixed ports, and the current
controls are just starting and stopping the whole cluster.

- It responds to simple GET requests, and responds to CLUSTER NODES
  with a static string (this finally needs to be dynamic..)

- The cluster uses libevent and handles socket events in an own thread,
  i.e its event loop in run in parallell with the testcase.

- Added the new suite to be run in CI