### PR TITLE
Tests using simulated Redis node

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -2377,8 +2377,8 @@ static cluster_node *node_get_by_ask_error_reply(redisClusterContext *cc,
                 dictAdd(cc->nodes, sdsnewlen(node->addr, sdslen(node->addr)),
                         node);
 
-                part = NULL;
-                ip_port = NULL;
+                part[1] = NULL;
+                ip_port[0] = NULL;
             } else {
                 node = de->val;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -89,3 +89,13 @@ if(ENABLE_SSL)
   target_link_libraries(example_async_tls hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
   add_dependencies(example_async_tls generate_tls_configs)
 endif()
+
+# Tests using simulated redis node
+add_executable(clusterclient clusterclient.c)
+target_link_libraries(clusterclient hiredis_cluster hiredis ${SSL_LIBRARY})
+add_test(NAME set-get-test
+  COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/set-get-test.sh" "$<TARGET_FILE:clusterclient>"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+add_test(NAME ask-redirect-test
+  COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/ask-redirect-test.sh" "$<TARGET_FILE:clusterclient>"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -1,0 +1,46 @@
+/*
+ * This program connects to a cluster and then reads commands from stdin, such
+ * as "SET foo bar", one per line and prints the results to stdout.
+ */
+
+#include "hircluster.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc < 1) {
+        fprintf(stderr, "Usage: clusterclient HOST:PORT\n");
+        exit(1);
+    }
+    const char *initnode = argv[1];
+
+    struct timeval timeout = {1, 500000}; // 1.5s
+
+    redisClusterContext *cc = redisClusterContextInit();
+    redisClusterSetOptionAddNodes(cc, initnode);
+    redisClusterSetOptionConnectTimeout(cc, timeout);
+    redisClusterSetOptionRouteUseSlots(cc);
+    redisClusterConnect2(cc);
+    if (cc && cc->err) {
+        fprintf(stderr, "Connect error: %s\n", cc->errstr);
+        exit(100);
+    }
+
+    char command[256];
+    while (fgets(command, 256, stdin)) {
+        size_t len = strlen(command);
+        if (command[len - 1] == '\n') // Chop trailing line break
+            command[len - 1] = '\0';
+        redisReply *reply = (redisReply *)redisClusterCommand(cc, command);
+        if (cc->err) {
+            fprintf(stderr, "redisClusterCommand error: %s\n", cc->errstr);
+            exit(101);
+        }
+        printf("%s\n", reply->str);
+        freeReplyObject(reply);
+    }
+
+    redisClusterFree(cc);
+    return 0;
+}

--- a/tests/scripts/ask-redirect-test.sh
+++ b/tests/scripts/ask-redirect-test.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient}
+testname=ask-redirect-test
+
+# Sync processes waiting for CONT signals.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid1=$!;
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid2=$!;
+
+# Start simulated redis node #1
+timeout 5s ./simulated-redis.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid123"]]]
+EXPECT RECONNECT
+EXPECT ["GET", "foo"]
+SEND -ASK 12182 127.0.0.1:7402
+EXPECT CLOSE
+EOF
+server1=$!
+
+# Start simulated redis node #2
+timeout 5s ./simulated-redis.pl -p 7402 -d --sigcont $syncpid2 <<'EOF' &
+EXPECT ["ASKING"]
+SEND +OK
+EXPECT ["GET", "foo"]
+SEND "bar"
+EXPECT CLOSE
+EOF
+server2=$!
+
+# Wait until both nodes are ready to accept client connections
+wait $syncpid1 $syncpid2;
+
+# Run client
+echo 'GET foo' | timeout 3s "$clientprog" 127.0.0.1:7401 > "$testname.out"
+clientexit=$?
+
+# Wait for servers to exit
+wait $server1; server1exit=$?
+wait $server2; server2exit=$?
+
+# Check exit statuses
+if [ $server1exit -ne 0 ]; then
+    echo "Simulated server #1 exited with status $server1exit"
+    exit $server1exit
+fi
+if [ $server2exit -ne 0 ]; then
+    echo "Simulated server #2 exited with status $server2exit"
+    exit $server2exit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from clusterclient
+echo 'bar' | cmp "$testname.out" - || exit 99
+
+# Clean up
+rm "$testname.out"

--- a/tests/scripts/set-get-test.sh
+++ b/tests/scripts/set-get-test.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient}
+testname=set-get-test
+
+# Sync process just waiting for server to be ready to accept connection.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid=$!
+
+# Start simulated server
+timeout 5s ./simulated-redis.pl -p 7400 -d --sigcont $syncpid <<'EOF' &
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 16383, ["127.0.0.1", 7400, "nodeid123"]]]
+EXPECT RECONNECT
+EXPECT ["SET", "foo", "bar"]
+SEND +OK
+EXPECT ["GET", "foo"]
+SEND "bar"
+EXPECT CLOSE
+EOF
+server=$!
+
+# Wait until server is ready to accept client connection
+wait $syncpid;
+
+# Run client
+timeout 3s "$clientprog" 127.0.0.1:7400 > "$testname.out" <<'EOF'
+SET foo bar
+GET foo
+EOF
+clientexit=$?
+
+# Wait for server to exit
+wait $server; serverexit=$?
+
+# Check exit statuses
+if [ $serverexit -ne 0 ]; then
+    echo "Simulated server exited with status $serverexit"
+    exit $serverexit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from clusterclient
+printf 'OK\nbar\n' | cmp "$testname.out" - || exit 99
+
+# Clean up
+rm "$testname.out"

--- a/tests/scripts/simulated-redis.pl
+++ b/tests/scripts/simulated-redis.pl
@@ -1,0 +1,233 @@
+#!/usr/bin/perl
+
+# A tool for simulating the traffic of a Redis node.
+#
+# Copyright 2020 Ericsson Software Technology <viktor.soderqvist@est.tech>
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use warnings;
+use Socket;
+
+my $port = 7000;
+my $debug = 0;
+my ($sig, $sig_pid);
+
+# Parse command line args
+while ($_ = shift) {
+    if (/^(?:-p|--port)$/) {
+        $port = shift;
+        die "Bad port: $port\n" unless $port > 0;
+    } elsif (/^--sig(cont|alrm|int|hup|term)$/) {
+        $sig = uc $1;
+        $sig_pid = shift;
+        die "Pid expected after $_\n" unless $sig_pid;
+    } elsif (/^(?:-d|--debug)$/) {
+        $debug = 1;
+    } elsif (/^(?:-h|--help)$/) {
+        map { print "$_\n" }
+            "Usage: $0 [ OPTIONS ]",
+            "",
+            "Acts as a Redis node, communicating with a single client according to",
+            "expected traffic provided as events on stdin.",
+            "",
+            "Options:",
+            "",
+            "  -p PORT, --port PORT   TCP port to use.",
+            "           --sigSIG PID  Send SIG to PID when ready to accept a",
+            "                         client connection.",
+            "  -d,       --debug      Enable debug printouts.",
+            "  -h,       --help       Help.",
+            "",
+            "Expected traffic is to be provided on stdin, one event per line,",
+            "where the following events are accepted:",
+            "",
+            "  SEND response          Send response to the client.",
+            "  EXPECT command         Receive expected command from the client.",
+            "  CLOSE                  Close the connection to the client.",
+            "  EXPECT CLOSE           Wait for the client to close the connection.",
+            "  EXPECT RECONNECT       Wait for the client to close and reconnect.",
+            "  SLEEP n                Sleep n seconds.",
+            "",
+            "The command and response in the events above is provided in a subset",
+            "of Perl syntax. Examples:",
+            "",
+            "  EXPECT [\"GET\", \"foo\"]",
+            "  SEND \"bar\"",
+            "",
+            "The response (after SEND) can also be represented in raw backslash-",
+            "escaped Redis protocol data, optionally without the final '\\r\\n'.",
+            "Examples:",
+            "",
+            "  SEND +OK",
+            "  SEND -ERR Some error",
+            "  SEND \$3\\r\\nfoo\\r\\n";
+        exit;
+    } else {
+        die "Bad option: $_\n";
+    }
+}
+
+my $listener;   # Listener socket
+my $connection; # Connection socket
+
+END {
+    close $listener if $listener;
+}
+
+socket($listener, PF_INET, SOCK_STREAM, getprotobyname("tcp"))
+    or die "socket: $!\n";
+setsockopt($listener, SOL_SOCKET, SO_REUSEADDR, pack("l", 1))
+    or die "setsockopt: $!\n";
+bind($listener, sockaddr_in($port, INADDR_ANY))
+    or die "bind: $!\n";
+listen($listener, 5)
+    or die "listen: $!\n";
+print "(port $port) Listening.\n" if $debug;
+kill $sig, $sig_pid if $sig_pid;
+my $peer_addr = accept($connection, $listener);
+my($client_port, $client_addr) = sockaddr_in($peer_addr);
+my $name = gethostbyaddr($client_addr, AF_INET);
+print "(port $port) Connection from $name [", inet_ntoa($client_addr), "]",
+    " on client port $client_port.\n" if $debug;
+
+# Loop over events on stdin.
+while (<>) {
+    next if /^#/; # skip commented-out events
+    print "(port $port) $_" if $debug;
+    if (/^SEND (.*)/) {
+        my $data = $1;
+        if ($data =~ /^[-+\$\*:]/) {
+            # Redis protocol with character escapes
+            # e.g. '-ERR Unknown command: FOO\r\n'
+            $data = unescape($data);
+            $data .= "\r\n" unless $data =~ /\r\n$/;
+        } else {
+            # e.g. '["foo", "bar", 42]'
+            $data = redis_encode(eval $1);
+        }
+        print $connection $data;
+        flush $connection;
+    } elsif (/^CLOSE$/) {
+        close $connection;
+    } elsif (/^EXPECT CLOSE$/) {
+        my $buffer;
+        my $bytes_read = read $connection, $buffer, 1;
+        die "(port $port) Data received from peer when close is expected.\n"
+            if $bytes_read;
+        print "(port $port) Client disconnected.\n" if $debug;
+        close $connection;
+    } elsif (/^EXPECT RECONNECT$/) {
+        my $buffer;
+        my $bytes_read = read $connection, $buffer, 1;
+        die "(port $port) Data received from peer when reconnect is expected.\n"
+            if $bytes_read;
+        close $connection;
+        print "(port $port) Client disconnected.\n" if $debug;
+        my $peer_addr = accept($connection, $listener);
+        my($client_port, $client_addr) = sockaddr_in($peer_addr);
+        my $name = gethostbyaddr($client_addr, AF_INET);
+        print "(port $port) Reconnect from $name [", inet_ntoa($client_addr),
+            "] on client port $client_port.\n" if $debug;
+    } elsif (/^EXPECT ([\[\"].*)/) {
+        my $expected = eval $1;
+        my $received = recv_command($connection);
+        my $expected_str = pretty_format_command($expected);
+        my $received_str = pretty_format_command($received);
+        if ($expected_str ne $received_str) {
+            die "(port $port) Unexpected $received_str received.\n" .
+                "Expected $expected_str.\n";
+        }
+    } elsif (/^SLEEP (\d+)$/) {
+        sleep $1;
+    } else {
+        die "(port $port) Unexpected event: $_\n";
+    }
+}
+print "(port $port) Done.\n" if $debug;
+exit;
+
+sub redis_encode {
+    my $x = shift;
+    return ("*" . @$x . "\r\n" . join '', map { redis_encode($_) } @$x)
+        if ref $x eq "ARRAY";
+    return ":$x\r\n"
+        unless ($x ^ $x) ne "0"; # hack to check if int or string
+    return "\$" . length($x) . "\r\n$x\r\n";
+}
+
+sub recv_command {
+    my $connection = shift;
+    my $old_rec_sep = $/;
+    $/ = "\r\n";
+    $_ = <$connection>;
+    die "(port $port) The peer has closed the connection\n" if !defined $_;
+    my $result;
+    if (/^\*(\d+)\r\n$/) {
+        my $n = $1;
+        $result = [];
+        for (my $i = 0; $i < $n; $i++) {
+            push @$result, recv_command($connection);
+        }
+    } elsif (/^\$0\r\n$/) {
+        $result = "";
+        $_ = <$connection>;
+        die "(port $port) Expected \\r\\n after empty string\n"
+            unless /^\r\n$/;
+    } elsif (/^\$(\d+)\r\n$/) {
+        my $remaining = $1;
+        $result = "";
+        my $buffer;
+        do {
+            my $read = read $connection, $buffer, $remaining;
+            die "(port $port) Unexpected EOF while receiving command\n"
+                unless $read;
+            $result .= $buffer;
+            $remaining -= $read;
+        } while ($remaining > 0);
+        $_ = <$connection>;
+        die "(port $port) Expected \\r\\n after string\n" unless /^\r\n$/
+    } else {
+        die "Unexpected command: $_\n";
+    }
+    $/ = $old_rec_sep;
+    return $result;
+}
+
+# ["GET", "foo\tbar"] => '["GET", "foo\tbar"]'
+sub pretty_format_command {
+    my $x = shift;
+    return "[" . join(", ", map { pretty_format_command($_) } @$x) . "]"
+        if ref $x eq "ARRAY";
+    return '"' . escape($x) . '"'
+        if ref $x eq "";
+    die "Can't serialize " . ref $x . " $x\n";
+}
+
+# Escape special chars to binary data readable
+# "hello\r\n" => "hello\\r\\n"
+sub escape {
+    $_ = shift;
+    s/([^A-Za-z0-9\/\-_.,:;!?~\*'(){}\^\$])/ escape_char($1) /eg;
+    return $_;
+}
+sub escape_char {
+    $_ = shift;
+    return "\\r" if /\r/; # nicer than \x0d, etc.
+    return "\\n" if /\n/;
+    return "\\t" if /\t/;
+    return '\\"' if /\"/;
+    return "\\\\" if /\\/;
+    return sprintf "\\x%02x", ord $_;
+}
+
+# "hello\\r\\n" => "hello\r\n"
+sub unescape {
+    $_ = shift;
+    s/\\([tnrfbae\\]|x\{[0-9a-fA-F]+\}|x[0-9a-fA-F]{1,2}|0[0-7]{0,2})/eval "\"\\$1\""/eg;
+    return $_;
+}


### PR DESCRIPTION
Test cases using a script simultating one or more Redis nodes, with exact expectations on traffic. The PR contains:

* A Perl script simulating a Redis node, given expected traffic events on stdin.
* A C program wrapping the hiredis-cluster library, performing Redis commands from stdin and writing the results on stdout.
* Test cases (shell script):
  * A simple SET and GET test case using a simulated Redis node
  * An ASK redirection test case using two simulated Redis nodes
* A memory leak in the ASK redirect handling detected and fixed