### PR TITLE
Add code formatting target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,15 @@ if(NOT DISABLE_TESTS)
   add_subdirectory(tests)
 endif()
 
+# Code formatting target
+find_program(CLANG_FORMAT "clang-format")
+file(GLOB_RECURSE FILES_TO_FORMAT
+  ${PROJECT_SOURCE_DIR}/*.[ch]
+)
+add_custom_target(format
+  COMMAND ${CLANG_FORMAT} -i ${FILES_TO_FORMAT}
+)
+
 configure_file(hiredis_cluster.pc.in hiredis_cluster.pc @ONLY)
 
 install(TARGETS hiredis_cluster

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+:tada:Thanks for taking the time to contribute!:tada:
+
+The following is a set of guidelines for contributing to hiredis-cluster.
+
+The basics about setting up the project, building and testing is covered in
+the [README](README.md).
+
+## Coding conventions
+
+### Code style
+
+Adhere to the existing coding style and make sure to mimic best possible.
+
+### Code formatting
+
+To have a common look-and-feel [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
+is used for code formatting. The formatting rules can be applied to the
+source code by running the following make target in your build directory:
+
+```sh
+$ make format
+```
+
+## Submitting changes
+
+* Run the formatter before committing when contributing to this project (`make format`).
+* Cover new behaviour with tests when possible.
+
+## Links
+
+* [clang-format](https://apt.llvm.org/) for code formatting


### PR DESCRIPTION
* Added a make target for code formatting using `clang-format`
  Code will be formatted according to existing rule by running `make format`
  This will make sure the `static checker` job in CI accepts changed code.

* Added an initial CONTRIBUTING.md file. To be improved