### PR TITLE
Leak corrections and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,44 +8,34 @@ env:
 
 jobs:
   checkers:
+    name: Run static checkers
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check (.c and .h)
       uses: jidicula/clang-format-action@master
 
-  build:
+  sanitizers:
+    name: Test with -fsanitizer=${{ matrix.sanitizer }}
     runs-on: ubuntu-latest
-
     strategy:
+      fail-fast: false
       matrix:
-        compiler: [gcc, clang]
-
+        sanitizer: [thread, undefined] # LEAK TO BE CORRECTED: leak, address
     steps:
     - name: Prepare
       run: sudo apt install libevent-dev
-
     - uses: actions/checkout@v2
-
     - name: Create build folder
       run: cmake -E make_directory build
-
     - name: Generate makefiles
-      env:
-        CC: ${{ matrix.compiler }}
-        CXX: ${{ matrix.compiler }}
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
       shell: bash
       working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON ..
-
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
     - name: Build
       shell: bash
       working-directory: build
-      run: cmake --build . --config $BUILD_TYPE
-
-    # Run CI tests
+      run: VERBOSE=1 make
     - name: Setup clusters
       shell: bash
       working-directory: build
@@ -57,7 +47,47 @@ jobs:
     - name: Run tests
       shell: bash
       working-directory: build
-      run: make test
+      run: make CTEST_OUTPUT_ON_FAILURE=1 test
+    - name: Teardown clusters
+      working-directory: build
+      shell: bash
+      run: make stop
+
+  build:
+    name: Build with ${{ matrix.compiler }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    steps:
+    - name: Prepare
+      run: sudo apt install libevent-dev
+    - uses: actions/checkout@v2
+    - name: Create build folder
+      run: cmake -E make_directory build
+    - name: Generate makefiles
+      env:
+        CC: ${{ matrix.compiler }}
+        CXX: ${{ matrix.compiler }}
+      shell: bash
+      working-directory: build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON ..
+    - name: Build
+      shell: bash
+      working-directory: build
+      run: cmake --build . --config $BUILD_TYPE
+    - name: Setup clusters
+      shell: bash
+      working-directory: build
+      run: make start
+    - name: Wait for clusters to start..
+      uses: jakejarvis/wait-action@master
+      with:
+        time: '20s'
+    - name: Run tests
+      shell: bash
+      working-directory: build
+      run: make CTEST_OUTPUT_ON_FAILURE=1 test
     - name: Teardown clusters
       working-directory: build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,49 +15,13 @@ jobs:
     - name: Run clang-format style check (.c and .h)
       uses: jidicula/clang-format-action@master
 
-  sanitizers:
-    name: Test with -fsanitizer=${{ matrix.sanitizer }}
+  build:
+    name: Build [${{ matrix.compiler }}, sanitizer="${{ matrix.sanitizer }}"]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [thread, undefined] # LEAK TO BE CORRECTED: leak, address
-    steps:
-    - name: Prepare
-      run: sudo apt install libevent-dev
-    - uses: actions/checkout@v2
-    - name: Create build folder
-      run: cmake -E make_directory build
-    - name: Generate makefiles
-      shell: bash
-      working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
-    - name: Build
-      shell: bash
-      working-directory: build
-      run: VERBOSE=1 make
-    - name: Setup clusters
-      shell: bash
-      working-directory: build
-      run: make start
-    - name: Wait for clusters to start..
-      uses: jakejarvis/wait-action@master
-      with:
-        time: '20s'
-    - name: Run tests
-      shell: bash
-      working-directory: build
-      run: make CTEST_OUTPUT_ON_FAILURE=1 test
-    - name: Teardown clusters
-      working-directory: build
-      shell: bash
-      run: make stop
-
-  build:
-    name: Build with ${{ matrix.compiler }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
+        sanitizer: ["", thread, undefined, leak, address]
         compiler: [gcc, clang]
     steps:
     - name: Prepare
@@ -66,16 +30,16 @@ jobs:
     - name: Create build folder
       run: cmake -E make_directory build
     - name: Generate makefiles
+      shell: bash
       env:
         CC: ${{ matrix.compiler }}
         CXX: ${{ matrix.compiler }}
-      shell: bash
       working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON ..
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
     - name: Build
       shell: bash
       working-directory: build
-      run: cmake --build . --config $BUILD_TYPE
+      run: VERBOSE=1 make
     - name: Setup clusters
       shell: bash
       working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 include(GNUInstallDirs)
 project(hiredis-cluster)
 
+# Options
 option(DOWNLOAD_HIREDIS  "Download the dependency hiredis from GitHub" ON)
 option(ENABLE_SSL        "Enable SSL/TLS support" OFF)
 option(DISABLE_TESTS     "Disable compilation of test" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ getVersionBit(HIREDIS_CLUSTER_SONAME)
 set(VERSION "${HIREDIS_CLUSTER_MAJOR}.${HIREDIS_CLUSTER_MINOR}.${HIREDIS_CLUSTER_PATCH}")
 message("Detected version: ${VERSION}")
 
+# Build using a sanitizer
+if(USE_SANITIZER)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=${USE_SANITIZER}")
+endif()
+
 project(hiredis-cluster
   VERSION "${VERSION}"
   LANGUAGES C)

--- a/README.md
+++ b/README.md
@@ -85,9 +85,14 @@ The following CMake options are available:
   * `ON` Enable IPv6 tests. Requires that IPv6 is
     [setup](https://docs.docker.com/config/daemon/ipv6/) in Docker.
 * `USE_SANITIZER`
-   Compile with a sanitizer. Options depends on
-   [compiler](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003daddress),
-   but usually: `address`, `thread`, `undefined`, `leak`
+   Compile using a specific sanitizer that detect issues. The value of this
+   option specifies which sanitizer to activate, but it depends on support in the
+   [compiler](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003daddress).
+   Common option values are: `address`, `thread`, `undefined`, `leak`
+
+Options needs to be set with the `-D` flag when generating makefiles, e.g.
+
+`cmake -DENABLE_SSL=ON -DUSE_SANITIZER=address ..`
 
 ### Build details
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ The following CMake options are available:
   * `OFF` (default)
   * `ON` Enable IPv6 tests. Requires that IPv6 is
     [setup](https://docs.docker.com/config/daemon/ipv6/) in Docker.
+* `USE_SANITIZER`
+   Compile with a sanitizer. Options depends on
+   [compiler](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003daddress),
+   but usually: `address`, `thread`, `undefined`, `leak`
 
 ### Build details
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,8 @@ endif()
 
 # Debug mode for tests
 set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
+# Make sure ctest gives the output when tests fail
+list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 
 add_executable(ct_async ct_async.c)
 target_link_libraries(ct_async hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -30,6 +30,48 @@ void test_exists(redisClusterContext *cc) {
     freeReplyObject(reply);
 }
 
+void test_mset(redisClusterContext *cc) {
+    redisReply *reply;
+    reply = (redisReply *)redisClusterCommand(
+        cc, "MSET key1 mset1 key2 mset2 key3 mset3");
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    reply = (redisReply *)redisClusterCommand(cc, "GET key1");
+    CHECK_REPLY_STR(cc, reply, "mset1");
+    freeReplyObject(reply);
+
+    reply = (redisReply *)redisClusterCommand(cc, "GET key2");
+    CHECK_REPLY_STR(cc, reply, "mset2");
+    freeReplyObject(reply);
+
+    reply = (redisReply *)redisClusterCommand(cc, "GET key3");
+    CHECK_REPLY_STR(cc, reply, "mset3");
+    freeReplyObject(reply);
+}
+
+void test_mget(redisClusterContext *cc) {
+    redisReply *reply;
+    reply = (redisReply *)redisClusterCommand(cc, "SET key1 mget1");
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    reply = (redisReply *)redisClusterCommand(cc, "SET key2 mget2");
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    reply = (redisReply *)redisClusterCommand(cc, "SET key3 mget3");
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    reply = (redisReply *)redisClusterCommand(cc, "MGET key1 key2 key3");
+    CHECK_REPLY_ARRAY(cc, reply, 3);
+    CHECK_REPLY_STR(cc, reply->element[0], "mget1");
+    CHECK_REPLY_STR(cc, reply->element[1], "mget2");
+    CHECK_REPLY_STR(cc, reply->element[2], "mget3");
+    freeReplyObject(reply);
+}
+
 int main() {
     struct timeval timeout = {0, 500000};
 
@@ -43,6 +85,8 @@ int main() {
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
 
     test_exists(cc);
+    test_mset(cc);
+    test_mget(cc);
 
     redisClusterFree(cc);
     return 0;

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -36,4 +36,11 @@
         ASSERT_MSG((strcmp(_reply->str, _str) == 0), _ctx->errstr);            \
     }
 
+#define CHECK_REPLY_ARRAY(_ctx, _reply, _num_of_elements)                      \
+    {                                                                          \
+        CHECK_REPLY(_ctx, _reply);                                             \
+        CHECK_REPLY_TYPE(_reply, REDIS_REPLY_ARRAY);                           \
+        ASSERT_MSG(_reply->elements == _num_of_elements, _ctx->errstr);        \
+    }
+
 #endif


### PR DESCRIPTION
* Correcting 2 iterator leaks, now covered with tests.
  Leaks in multi-command handling:
  * redisClusterGetReply()
  * command_post_fragment()

* Add option to build using sanitizers
  * The option is set when generating makefiles, like the other configs:
    `cmake -DDOWNLOAD_HIREDIS=ON -DUSE_SANITIZER=leak ..`

* Build and test using sanitizers in CI aswell