### PR TITLE
Safe allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hiredis-cluster is a fork of Hiredis-vip, with the following improvements:
 * Using CMake as build system
 * Code style guide (using clang-format)
 * Improved testing
-* Memory leak corrections
+* Memory leak corrections and allocation failure handling
 
 ## Features
 

--- a/adlist.c
+++ b/adlist.c
@@ -41,7 +41,7 @@
 hilist *listCreate(void) {
     struct hilist *list;
 
-    if ((list = hi_alloc(sizeof(*list))) == NULL)
+    if ((list = hi_malloc(sizeof(*list))) == NULL)
         return NULL;
     list->head = list->tail = NULL;
     list->len = 0;
@@ -79,7 +79,7 @@ void listRelease(hilist *list) {
 hilist *listAddNodeHead(hilist *list, void *value) {
     listNode *node;
 
-    if ((node = hi_alloc(sizeof(*node))) == NULL)
+    if ((node = hi_malloc(sizeof(*node))) == NULL)
         return NULL;
     node->value = value;
     if (list->len == 0) {
@@ -104,7 +104,7 @@ hilist *listAddNodeHead(hilist *list, void *value) {
 hilist *listAddNodeTail(hilist *list, void *value) {
     listNode *node;
 
-    if ((node = hi_alloc(sizeof(*node))) == NULL)
+    if ((node = hi_malloc(sizeof(*node))) == NULL)
         return NULL;
     node->value = value;
     if (list->len == 0) {
@@ -124,7 +124,7 @@ hilist *listInsertNode(hilist *list, listNode *old_node, void *value,
                        int after) {
     listNode *node;
 
-    if ((node = hi_alloc(sizeof(*node))) == NULL)
+    if ((node = hi_malloc(sizeof(*node))) == NULL)
         return NULL;
     node->value = value;
     if (after) {
@@ -176,7 +176,7 @@ void listDelNode(hilist *list, listNode *node) {
 listIter *listGetIterator(hilist *list, int direction) {
     listIter *iter;
 
-    if ((iter = hi_alloc(sizeof(*iter))) == NULL)
+    if ((iter = hi_malloc(sizeof(*iter))) == NULL)
         return NULL;
     if (direction == AL_START_HEAD)
         iter->next = list->head;

--- a/adlist.c
+++ b/adlist.c
@@ -27,10 +27,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include <hiredis/alloc.h>
+#include <stdlib.h>
 
 #include "adlist.h"
 #include "hiutil.h"
-#include <stdlib.h>
 
 /* Create a new list. The created list can be freed with
  * AlFreeList(), but private value of every node need to be freed

--- a/adlist.c
+++ b/adlist.c
@@ -281,6 +281,9 @@ listNode *listSearchKey(hilist *list, void *key) {
     listNode *node;
 
     iter = listGetIterator(list, AL_START_HEAD);
+    if (iter == NULL) {
+        return NULL;
+    }
     while ((node = listNext(iter)) != NULL) {
         if (list->match) {
             if (list->match(node->value, key)) {

--- a/command.c
+++ b/command.c
@@ -1606,7 +1606,9 @@ error:
     r->result = CMD_PARSE_ERROR;
     errno = EINVAL;
     if (r->errstr == NULL) {
-        r->errstr = hi_alloc(100 * sizeof(*r->errstr));
+        r->errstr = hi_malloc(100 * sizeof(*r->errstr));
+        if (r->errstr == NULL)
+            return;
     }
 
     len = _scnprintf(
@@ -1618,7 +1620,7 @@ error:
 
 struct cmd *command_get() {
     struct cmd *command;
-    command = hi_alloc(sizeof(struct cmd));
+    command = hi_malloc(sizeof(struct cmd));
     if (command == NULL) {
         return NULL;
     }

--- a/command.c
+++ b/command.c
@@ -1,5 +1,6 @@
 #include <ctype.h>
 #include <errno.h>
+#include <hiredis/alloc.h>
 
 #include "command.h"
 #include "hiarray.h"
@@ -1655,15 +1656,18 @@ void command_destroy(struct cmd *command) {
 
     if (command->cmd != NULL) {
         hi_free(command->cmd);
+        command->cmd = NULL;
     }
 
     if (command->errstr != NULL) {
         hi_free(command->errstr);
+        command->errstr = NULL;
     }
 
     if (command->keys != NULL) {
         command->keys->nelem = 0;
         hiarray_destroy(command->keys);
+        command->keys = NULL;
     }
 
     if (command->frag_seq != NULL) {
@@ -1671,9 +1675,7 @@ void command_destroy(struct cmd *command) {
         command->frag_seq = NULL;
     }
 
-    if (command->reply != NULL) {
-        freeReplyObject(command->reply);
-    }
+    freeReplyObject(command->reply);
 
     if (command->sub_commands != NULL) {
         listRelease(command->sub_commands);

--- a/command.c
+++ b/command.c
@@ -1588,25 +1588,17 @@ void redis_parse_cmd(struct cmd *r) {
     return;
 
 done:
-
     ASSERT(r->type > CMD_UNKNOWN && r->type < CMD_SENTINEL);
     r->result = CMD_PARSE_OK;
     return;
 
-oom:
-
-    r->result = CMD_PARSE_ENOMEM;
-    return;
-
 error:
-
     r->result = CMD_PARSE_ERROR;
     errno = EINVAL;
     if (r->errstr == NULL) {
         r->errstr = hi_malloc(100 * sizeof(*r->errstr));
         if (r->errstr == NULL) {
-            r->result = CMD_PARSE_ENOMEM;
-            return;
+            goto oom;
         }
     }
 
@@ -1615,6 +1607,10 @@ error:
         "Parse command error. Cmd type: %d, state: %d, break position: %d.",
         r->type, state, (int)(p - r->cmd));
     r->errstr[len] = '\0';
+    return;
+
+oom:
+    r->result = CMD_PARSE_ENOMEM;
 }
 
 struct cmd *command_get() {

--- a/dict.c
+++ b/dict.c
@@ -70,7 +70,9 @@ static void _dictReset(dict *ht) {
 
 /* Create a new hash table */
 static dict *dictCreate(dictType *type, void *privDataPtr) {
-    dict *ht = malloc(sizeof(*ht));
+    dict *ht = hi_malloc(sizeof(*ht));
+    if (ht == NULL)
+        return NULL;
     _dictInit(ht, type, privDataPtr);
     return ht;
 }
@@ -145,7 +147,9 @@ static int dictAdd(dict *ht, void *key, void *val) {
         return DICT_ERR;
 
     /* Allocates the memory and stores key */
-    entry = malloc(sizeof(*entry));
+    entry = hi_malloc(sizeof(*entry));
+    if (entry == NULL)
+        return DICT_ERR;
     entry->next = ht->table[index];
     ht->table[index] = entry;
 
@@ -207,7 +211,9 @@ static dictEntry *dictFind(dict *ht, const void *key) {
 }
 
 static dictIterator *dictGetIterator(dict *ht) {
-    dictIterator *iter = malloc(sizeof(*iter));
+    dictIterator *iter = hi_malloc(sizeof(*iter));
+    if (iter == NULL)
+        return NULL;
 
     iter->ht = ht;
     iter->index = -1;

--- a/dict.c
+++ b/dict.c
@@ -96,7 +96,9 @@ static int dictExpand(dict *ht, unsigned long size) {
     _dictInit(&n, ht->type, ht->privdata);
     n.size = realsize;
     n.sizemask = realsize - 1;
-    n.table = calloc(realsize, sizeof(dictEntry *));
+    n.table = hi_calloc(realsize, sizeof(dictEntry *));
+    if (n.table == NULL)
+        return DICT_ERR;
 
     /* Copy all the elements from the old to the new table:
      * note that if the old hash table is empty ht->size is zero,

--- a/dict.c
+++ b/dict.c
@@ -32,6 +32,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
@@ -73,6 +74,7 @@ static dict *dictCreate(dictType *type, void *privDataPtr) {
     dict *ht = hi_malloc(sizeof(*ht));
     if (ht == NULL)
         return NULL;
+
     _dictInit(ht, type, privDataPtr);
     return ht;
 }
@@ -129,7 +131,6 @@ static int dictExpand(dict *ht, unsigned long size) {
     }
     assert(ht->used == 0);
     hi_free(ht->table);
-    ht->table = NULL;
 
     /* Remap the new hashtable in the old */
     *ht = n;
@@ -150,6 +151,7 @@ static int dictAdd(dict *ht, void *key, void *val) {
     entry = hi_malloc(sizeof(*entry));
     if (entry == NULL)
         return DICT_ERR;
+
     entry->next = ht->table[index];
     ht->table[index] = entry;
 
@@ -181,8 +183,6 @@ static int _dictClear(dict *ht) {
     }
     /* Free the table and the allocated cache structure */
     hi_free(ht->table);
-    ht->table = NULL;
-
     /* Re-initialize the table */
     _dictReset(ht);
     return DICT_OK; /* never fails */

--- a/dict.c
+++ b/dict.c
@@ -32,11 +32,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
-#include "dict.h"
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
+
+#include "dict.h"
 
 /* -------------------------- private prototypes ---------------------------- */
 
@@ -124,7 +124,8 @@ static int dictExpand(dict *ht, unsigned long size) {
         }
     }
     assert(ht->used == 0);
-    free(ht->table);
+    hi_free(ht->table);
+    ht->table = NULL;
 
     /* Remap the new hashtable in the old */
     *ht = n;
@@ -167,13 +168,15 @@ static int _dictClear(dict *ht) {
             nextHe = he->next;
             dictFreeEntryKey(ht, he);
             dictFreeEntryVal(ht, he);
-            free(he);
+            hi_free(he);
             ht->used--;
             he = nextHe;
         }
     }
     /* Free the table and the allocated cache structure */
-    free(ht->table);
+    hi_free(ht->table);
+    ht->table = NULL;
+
     /* Re-initialize the table */
     _dictReset(ht);
     return DICT_OK; /* never fails */
@@ -182,7 +185,7 @@ static int _dictClear(dict *ht) {
 /* Clear & Release the hash table */
 static void dictRelease(dict *ht) {
     _dictClear(ht);
-    free(ht);
+    hi_free(ht);
 }
 
 static dictEntry *dictFind(dict *ht, const void *key) {
@@ -231,7 +234,7 @@ static dictEntry *dictNext(dictIterator *iter) {
     return NULL;
 }
 
-static void dictReleaseIterator(dictIterator *iter) { free(iter); }
+static void dictReleaseIterator(dictIterator *iter) { hi_free(iter); }
 
 /* ------------------------- private functions ------------------------------ */
 

--- a/hiarray.c
+++ b/hiarray.c
@@ -1,3 +1,4 @@
+#include <hiredis/alloc.h>
 #include <stdlib.h>
 
 #include "hiarray.h"
@@ -49,9 +50,8 @@ int hiarray_init(struct hiarray *a, uint32_t n, size_t size) {
 void hiarray_deinit(struct hiarray *a) {
     ASSERT(a->nelem == 0);
 
-    if (a->elem != NULL) {
-        hi_free(a->elem);
-    }
+    hi_free(a->elem);
+    a->elem = NULL;
 }
 
 uint32_t hiarray_idx(struct hiarray *a, void *elem) {

--- a/hiarray.c
+++ b/hiarray.c
@@ -32,21 +32,6 @@ void hiarray_destroy(struct hiarray *a) {
     hi_free(a);
 }
 
-int hiarray_init(struct hiarray *a, uint32_t n, size_t size) {
-    ASSERT(n != 0 && size != 0);
-
-    a->elem = hi_malloc(n * size);
-    if (a->elem == NULL) {
-        return HI_ENOMEM;
-    }
-
-    a->nelem = 0;
-    a->size = size;
-    a->nalloc = n;
-
-    return HI_OK;
-}
-
 void hiarray_deinit(struct hiarray *a) {
     ASSERT(a->nelem == 0);
 

--- a/hiarray.c
+++ b/hiarray.c
@@ -9,12 +9,12 @@ struct hiarray *hiarray_create(uint32_t n, size_t size) {
 
     ASSERT(n != 0 && size != 0);
 
-    a = hi_alloc(sizeof(*a));
+    a = hi_malloc(sizeof(*a));
     if (a == NULL) {
         return NULL;
     }
 
-    a->elem = hi_alloc(n * size);
+    a->elem = hi_malloc(n * size);
     if (a->elem == NULL) {
         hi_free(a);
         return NULL;
@@ -35,7 +35,7 @@ void hiarray_destroy(struct hiarray *a) {
 int hiarray_init(struct hiarray *a, uint32_t n, size_t size) {
     ASSERT(n != 0 && size != 0);
 
-    a->elem = hi_alloc(n * size);
+    a->elem = hi_malloc(n * size);
     if (a->elem == NULL) {
         return HI_ENOMEM;
     }

--- a/hiarray.h
+++ b/hiarray.h
@@ -35,7 +35,6 @@ static inline uint32_t hiarray_n(const struct hiarray *a) { return a->nelem; }
 
 struct hiarray *hiarray_create(uint32_t n, size_t size);
 void hiarray_destroy(struct hiarray *a);
-int hiarray_init(struct hiarray *a, uint32_t n, size_t size);
 void hiarray_deinit(struct hiarray *a);
 
 uint32_t hiarray_idx(struct hiarray *a, void *elem);

--- a/hircluster.c
+++ b/hircluster.c
@@ -1588,7 +1588,7 @@ int test_cluster_update_route(redisClusterContext *cc) {
 redisClusterContext *redisClusterContextInit(void) {
     redisClusterContext *cc;
 
-    cc = calloc(1, sizeof(redisClusterContext));
+    cc = hi_calloc(1, sizeof(redisClusterContext));
     if (cc == NULL)
         return NULL;
 
@@ -2898,7 +2898,6 @@ static void *command_post_fragment(redisClusterContext *cc, struct cmd *command,
     listReleaseIterator(list_iter);
 
     reply = hi_calloc(1, sizeof(*reply));
-
     if (reply == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         return NULL;

--- a/hircluster.c
+++ b/hircluster.c
@@ -858,7 +858,7 @@ dict *parse_cluster_slots(redisClusterContext *cc, redisReply *reply,
                         master = dictGetEntryVal(den);
                         ret = cluster_slot_ref_node(slot, master);
                         if (ret != REDIS_OK) {
-                            goto oom;
+                            goto error;
                         }
 
                         slot = NULL;
@@ -886,7 +886,7 @@ dict *parse_cluster_slots(redisClusterContext *cc, redisReply *reply,
 
                     ret = cluster_slot_ref_node(slot, master);
                     if (ret != REDIS_OK) {
-                        goto oom;
+                        goto error;
                     }
 
                     slot = NULL;
@@ -1767,6 +1767,7 @@ int redisClusterSetOptionAddNode(redisClusterContext *cc, const char *addr) {
     if (cc->nodes == NULL) {
         cc->nodes = dictCreate(&clusterNodesDictType, NULL);
         if (cc->nodes == NULL) {
+            __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
             return REDIS_ERR;
         }
     }
@@ -1955,6 +1956,7 @@ int redisClusterSetOptionConnectTimeout(redisClusterContext *cc,
     if (cc->connect_timeout == NULL) {
         cc->connect_timeout = hi_malloc(sizeof(struct timeval));
         if (cc->connect_timeout == NULL) {
+            __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
             return REDIS_ERR;
         }
     }
@@ -4169,7 +4171,7 @@ int redisClusterAsyncFormattedCommand(redisClusterAsyncContext *acc,
 
     cad = cluster_async_data_get();
     if (cad == NULL) {
-        goto error;
+        goto oom;
     }
 
     cad->acc = acc;

--- a/hircluster.c
+++ b/hircluster.c
@@ -2564,11 +2564,12 @@ static int command_pre_fragment(redisClusterContext *cc, struct cmd *command,
 
     key_count = hiarray_n(command->keys);
 
-    sub_commands = hi_zalloc(REDIS_CLUSTER_SLOTS * sizeof(*sub_commands));
+    sub_commands = hi_malloc(REDIS_CLUSTER_SLOTS * sizeof(*sub_commands));
     if (sub_commands == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         goto done;
     }
+    memset(sub_commands, 0, REDIS_CLUSTER_SLOTS * sizeof(*sub_commands));
 
     command->frag_seq = hi_malloc(key_count * sizeof(*command->frag_seq));
     if (command->frag_seq == NULL) {
@@ -2662,12 +2663,14 @@ static int command_pre_fragment(redisClusterContext *cc, struct cmd *command,
             sub_command->clen += 13 + num_str_len;
 
             sub_command->cmd =
-                hi_zalloc(sub_command->clen * sizeof(*sub_command->cmd));
+                hi_malloc(sub_command->clen * sizeof(*sub_command->cmd));
             if (sub_command->cmd == NULL) {
                 __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
                 slot_num = -1;
                 goto done;
             }
+            memset(sub_command->cmd, 0,
+                   sub_command->clen * sizeof(*sub_command->cmd));
 
             sub_command->cmd[idx++] = '*';
             memcpy(sub_command->cmd + idx, num_str, num_str_len);
@@ -2704,12 +2707,14 @@ static int command_pre_fragment(redisClusterContext *cc, struct cmd *command,
             sub_command->clen += 12 + num_str_len;
 
             sub_command->cmd =
-                hi_zalloc(sub_command->clen * sizeof(*sub_command->cmd));
+                hi_malloc(sub_command->clen * sizeof(*sub_command->cmd));
             if (sub_command->cmd == NULL) {
                 __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
                 slot_num = -1;
                 goto done;
             }
+            memset(sub_command->cmd, 0,
+                   sub_command->clen * sizeof(*sub_command->cmd));
 
             sub_command->cmd[idx++] = '*';
             memcpy(sub_command->cmd + idx, num_str, num_str_len);
@@ -2746,12 +2751,14 @@ static int command_pre_fragment(redisClusterContext *cc, struct cmd *command,
             sub_command->clen += 15 + num_str_len;
 
             sub_command->cmd =
-                hi_zalloc(sub_command->clen * sizeof(*sub_command->cmd));
+                hi_malloc(sub_command->clen * sizeof(*sub_command->cmd));
             if (sub_command->cmd == NULL) {
                 __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
                 slot_num = -1;
                 goto done;
             }
+            memset(sub_command->cmd, 0,
+                   sub_command->clen * sizeof(*sub_command->cmd));
 
             sub_command->cmd[idx++] = '*';
             memcpy(sub_command->cmd + idx, num_str, num_str_len);
@@ -2790,12 +2797,14 @@ static int command_pre_fragment(redisClusterContext *cc, struct cmd *command,
             sub_command->clen += 13 + num_str_len;
 
             sub_command->cmd =
-                hi_zalloc(sub_command->clen * sizeof(*sub_command->cmd));
+                hi_malloc(sub_command->clen * sizeof(*sub_command->cmd));
             if (sub_command->cmd == NULL) {
                 __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
                 slot_num = -1;
                 goto done;
             }
+            memset(sub_command->cmd, 0,
+                   sub_command->clen * sizeof(*sub_command->cmd));
 
             sub_command->cmd[idx++] = '*';
             memcpy(sub_command->cmd + idx, num_str, num_str_len);

--- a/hircluster.c
+++ b/hircluster.c
@@ -3029,8 +3029,7 @@ static int command_format_by_slot(redisClusterContext *cc, struct cmd *command,
 
     redis_parse_cmd(command);
     if (command->result == CMD_PARSE_ENOMEM) {
-        __redisClusterSetError(cc, REDIS_ERR_PROTOCOL,
-                               "Parse command error: out of memory");
+        __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         goto done;
     } else if (command->result != CMD_PARSE_OK) {
         __redisClusterSetError(cc, REDIS_ERR_PROTOCOL, command->errstr);

--- a/hircluster.c
+++ b/hircluster.c
@@ -331,7 +331,7 @@ static int cluster_slot_init(cluster_slot *slot, cluster_node *node) {
 static cluster_slot *cluster_slot_create(cluster_node *node) {
     cluster_slot *slot;
 
-    slot = hi_alloc(sizeof(*slot));
+    slot = hi_malloc(sizeof(*slot));
     if (slot == NULL) {
         return NULL;
     }
@@ -393,7 +393,7 @@ static copen_slot *cluster_open_slot_create(uint32_t slot_num, int migrate,
                                             cluster_node *node) {
     copen_slot *oslot;
 
-    oslot = hi_alloc(sizeof(*oslot));
+    oslot = hi_malloc(sizeof(*oslot));
     if (oslot == NULL) {
         return NULL;
     }
@@ -491,7 +491,7 @@ static cluster_node *node_get_with_slots(redisClusterContext *cc,
         goto error;
     }
 
-    node = hi_alloc(sizeof(cluster_node));
+    node = hi_malloc(sizeof(cluster_node));
     if (node == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         goto error;
@@ -543,7 +543,7 @@ static cluster_node *node_get_with_nodes(redisClusterContext *cc,
         return NULL;
     }
 
-    node = hi_alloc(sizeof(cluster_node));
+    node = hi_malloc(sizeof(cluster_node));
     if (node == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         return NULL;
@@ -1719,7 +1719,10 @@ redisClusterContext *redisClusterConnectWithTimeout(const char *addrs,
     }
 
     if (cc->connect_timeout == NULL) {
-        cc->connect_timeout = malloc(sizeof(struct timeval));
+        cc->connect_timeout = hi_malloc(sizeof(struct timeval));
+        if (cc->connect_timeout == NULL) {
+            return NULL;
+        }
     }
 
     memcpy(cc->connect_timeout, &tv, sizeof(struct timeval));
@@ -1801,7 +1804,7 @@ int redisClusterSetOptionAddNode(redisClusterContext *cc, const char *addr) {
             return REDIS_ERR;
         }
 
-        node = hi_alloc(sizeof(cluster_node));
+        node = hi_malloc(sizeof(cluster_node));
         if (node == NULL) {
             sdsfree(ip);
             __redisClusterSetError(cc, REDIS_ERR_OTHER,
@@ -1945,7 +1948,10 @@ int redisClusterSetOptionConnectTimeout(redisClusterContext *cc,
     }
 
     if (cc->connect_timeout == NULL) {
-        cc->connect_timeout = malloc(sizeof(struct timeval));
+        cc->connect_timeout = hi_malloc(sizeof(struct timeval));
+        if (cc->connect_timeout == NULL) {
+            return REDIS_ERR;
+        }
     }
 
     memcpy(cc->connect_timeout, &tv, sizeof(struct timeval));
@@ -1961,7 +1967,10 @@ int redisClusterSetOptionTimeout(redisClusterContext *cc,
     }
 
     if (cc->command_timeout == NULL) {
-        cc->command_timeout = malloc(sizeof(struct timeval));
+        cc->command_timeout = hi_malloc(sizeof(struct timeval));
+        if (cc->command_timeout == NULL) {
+            return REDIS_ERR;
+        }
         memcpy(cc->command_timeout, &tv, sizeof(struct timeval));
     } else if (cc->command_timeout->tv_sec != tv.tv_sec ||
                cc->command_timeout->tv_usec != tv.tv_usec) {
@@ -2349,7 +2358,7 @@ static cluster_node *node_get_by_ask_error_reply(redisClusterContext *cc,
         if (ip_port != NULL && ip_port_len == 2) {
             de = dictFind(cc->nodes, part[2]);
             if (de == NULL) {
-                node = hi_alloc(sizeof(cluster_node));
+                node = hi_malloc(sizeof(cluster_node));
                 if (node == NULL) {
                     __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
 
@@ -2561,7 +2570,7 @@ static int command_pre_fragment(redisClusterContext *cc, struct cmd *command,
         goto done;
     }
 
-    command->frag_seq = hi_alloc(key_count * sizeof(*command->frag_seq));
+    command->frag_seq = hi_malloc(key_count * sizeof(*command->frag_seq));
     if (command->frag_seq == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         goto done;
@@ -2951,7 +2960,7 @@ static void *command_post_fragment(redisClusterContext *cc, struct cmd *command,
     } else if (command->type == CMD_REQ_REDIS_MSET) {
         reply->type = REDIS_REPLY_STATUS;
         uint32_t str_len = strlen(REDIS_STATUS_OK);
-        reply->str = hi_alloc((str_len + 1) * sizeof(char *));
+        reply->str = hi_malloc((str_len + 1) * sizeof(char *));
         if (reply->str == NULL) {
             freeReplyObject(reply);
             __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
@@ -3598,7 +3607,7 @@ redisClusterAsyncInitialize(redisClusterContext *cc) {
         return NULL;
     }
 
-    acc = hi_alloc(sizeof(redisClusterAsyncContext));
+    acc = hi_malloc(sizeof(redisClusterAsyncContext));
     if (acc == NULL)
         return NULL;
 
@@ -3623,7 +3632,7 @@ redisClusterAsyncInitialize(redisClusterContext *cc) {
 static cluster_async_data *cluster_async_data_get(void) {
     cluster_async_data *cad;
 
-    cad = hi_alloc(sizeof(cluster_async_data));
+    cad = hi_malloc(sizeof(cluster_async_data));
     if (cad == NULL) {
         return NULL;
     }
@@ -4071,7 +4080,7 @@ int redisClusterAsyncFormattedCommand(redisClusterAsyncContext *acc,
         goto error;
     }
 
-    command->cmd = malloc(len * sizeof(*command->cmd));
+    command->cmd = hi_malloc(len * sizeof(*command->cmd));
     if (command->cmd == NULL) {
         __redisClusterAsyncSetError(acc, REDIS_ERR_OOM, "Out of memory");
         goto error;

--- a/hiutil.c
+++ b/hiutil.c
@@ -230,17 +230,6 @@ int _uint_len(uint32_t num) {
     return n;
 }
 
-void *_hi_zalloc(size_t size) {
-    void *p;
-
-    p = hi_malloc(size);
-    if (p != NULL) {
-        memset(p, 0, size);
-    }
-
-    return p;
-}
-
 void hi_stacktrace(int skip_count) {
     if (skip_count > 0) {
     }

--- a/hiutil.c
+++ b/hiutil.c
@@ -1,22 +1,24 @@
-#include "win32.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <hiredis/alloc.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #ifndef WIN32
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/time.h>
 #endif
-#include "hiutil.h"
-#include <sys/types.h>
 
 #ifdef HI_HAVE_BACKTRACE
 #include <execinfo.h>
 #endif
+
+#include "hiutil.h"
+#include "win32.h"
 
 #ifndef WIN32
 int hi_set_blocking(int sd) {
@@ -269,15 +271,6 @@ void *_hi_realloc(void *ptr, size_t size, const char *name, int line) {
     return p;
 }
 
-void _hi_free(void *ptr, const char *name, int line) {
-    ASSERT(ptr != NULL);
-
-    if (name == NULL && line == 1) {
-    }
-
-    free(ptr);
-}
-
 void hi_stacktrace(int skip_count) {
     if (skip_count > 0) {
     }
@@ -299,7 +292,7 @@ void hi_stacktrace(int skip_count) {
         printf("[%d] %s\n", j, symbols[i]);
     }
 
-    free(symbols);
+    hi_free(symbols);
 #endif
 }
 

--- a/hiutil.c
+++ b/hiutil.c
@@ -230,23 +230,10 @@ int _uint_len(uint32_t num) {
     return n;
 }
 
-void *_hi_alloc(size_t size, const char *name, int line) {
+void *_hi_zalloc(size_t size) {
     void *p;
 
-    ASSERT(size != 0);
-
-    p = malloc(size);
-
-    if (name == NULL && line == 1) {
-    }
-
-    return p;
-}
-
-void *_hi_zalloc(size_t size, const char *name, int line) {
-    void *p;
-
-    p = _hi_alloc(size, name, line);
+    p = hi_malloc(size);
     if (p != NULL) {
         memset(p, 0, size);
     }

--- a/hiutil.c
+++ b/hiutil.c
@@ -258,19 +258,6 @@ void *_hi_calloc(size_t nmemb, size_t size, const char *name, int line) {
     return _hi_zalloc(nmemb * size, name, line);
 }
 
-void *_hi_realloc(void *ptr, size_t size, const char *name, int line) {
-    void *p;
-
-    ASSERT(size != 0);
-
-    p = realloc(ptr, size);
-
-    if (name == NULL && line == 1) {
-    }
-
-    return p;
-}
-
 void hi_stacktrace(int skip_count) {
     if (skip_count > 0) {
     }

--- a/hiutil.c
+++ b/hiutil.c
@@ -254,10 +254,6 @@ void *_hi_zalloc(size_t size, const char *name, int line) {
     return p;
 }
 
-void *_hi_calloc(size_t nmemb, size_t size, const char *name, int line) {
-    return _hi_zalloc(nmemb * size, name, line);
-}
-
 void hi_stacktrace(int skip_count) {
     if (skip_count > 0) {
     }

--- a/hiutil.h
+++ b/hiutil.h
@@ -12,7 +12,6 @@ typedef SSIZE_T ssize_t;
 #define HI_OK 0
 #define HI_ERROR -1
 #define HI_EAGAIN -2
-#define HI_ENOMEM -3
 
 typedef int rstatus_t; /* return type */
 

--- a/hiutil.h
+++ b/hiutil.h
@@ -153,13 +153,6 @@ int hi_valid_port(int n);
 
 int _uint_len(uint32_t num);
 
-/*
- * Memory allocation wrapper.
- */
-#define hi_zalloc(_s) _hi_zalloc((size_t)(_s))
-
-void *_hi_zalloc(size_t size);
-
 #ifndef WIN32
 /*
  * Wrappers to send or receive n byte message on a blocking

--- a/hiutil.h
+++ b/hiutil.h
@@ -166,8 +166,6 @@ int _uint_len(uint32_t num);
 void *_hi_alloc(size_t size, const char *name, int line);
 void *_hi_zalloc(size_t size, const char *name, int line);
 
-#define hi_strndup(_s, _n) strndup((char *)(_s), (size_t)(_n));
-
 #ifndef WIN32
 /*
  * Wrappers to send or receive n byte message on a blocking

--- a/hiutil.h
+++ b/hiutil.h
@@ -168,17 +168,10 @@ int _uint_len(uint32_t num);
 
 #define hi_realloc(_p, _s) _hi_realloc(_p, (size_t)(_s), __FILE__, __LINE__)
 
-#define hi_free(_p)                                                            \
-    do {                                                                       \
-        _hi_free(_p, __FILE__, __LINE__);                                      \
-        (_p) = NULL;                                                           \
-    } while (0)
-
 void *_hi_alloc(size_t size, const char *name, int line);
 void *_hi_zalloc(size_t size, const char *name, int line);
 void *_hi_calloc(size_t nmemb, size_t size, const char *name, int line);
 void *_hi_realloc(void *ptr, size_t size, const char *name, int line);
-void _hi_free(void *ptr, const char *name, int line);
 
 #define hi_strndup(_s, _n) strndup((char *)(_s), (size_t)(_n));
 

--- a/hiutil.h
+++ b/hiutil.h
@@ -163,12 +163,8 @@ int _uint_len(uint32_t num);
 
 #define hi_zalloc(_s) _hi_zalloc((size_t)(_s), __FILE__, __LINE__)
 
-#define hi_calloc(_n, _s)                                                      \
-    _hi_calloc((size_t)(_n), (size_t)(_s), __FILE__, __LINE__)
-
 void *_hi_alloc(size_t size, const char *name, int line);
 void *_hi_zalloc(size_t size, const char *name, int line);
-void *_hi_calloc(size_t nmemb, size_t size, const char *name, int line);
 
 #define hi_strndup(_s, _n) strndup((char *)(_s), (size_t)(_n));
 

--- a/hiutil.h
+++ b/hiutil.h
@@ -166,12 +166,9 @@ int _uint_len(uint32_t num);
 #define hi_calloc(_n, _s)                                                      \
     _hi_calloc((size_t)(_n), (size_t)(_s), __FILE__, __LINE__)
 
-#define hi_realloc(_p, _s) _hi_realloc(_p, (size_t)(_s), __FILE__, __LINE__)
-
 void *_hi_alloc(size_t size, const char *name, int line);
 void *_hi_zalloc(size_t size, const char *name, int line);
 void *_hi_calloc(size_t nmemb, size_t size, const char *name, int line);
-void *_hi_realloc(void *ptr, size_t size, const char *name, int line);
 
 #define hi_strndup(_s, _n) strndup((char *)(_s), (size_t)(_n));
 

--- a/hiutil.h
+++ b/hiutil.h
@@ -154,17 +154,11 @@ int hi_valid_port(int n);
 int _uint_len(uint32_t num);
 
 /*
- * Memory allocation and free wrappers.
- *
- * These wrappers enables us to loosely detect double free, dangling
- * pointer access and zero-byte alloc.
+ * Memory allocation wrapper.
  */
-#define hi_alloc(_s) _hi_alloc((size_t)(_s), __FILE__, __LINE__)
+#define hi_zalloc(_s) _hi_zalloc((size_t)(_s))
 
-#define hi_zalloc(_s) _hi_zalloc((size_t)(_s), __FILE__, __LINE__)
-
-void *_hi_alloc(size_t size, const char *name, int line);
-void *_hi_zalloc(size_t size, const char *name, int line);
+void *_hi_zalloc(size_t size);
 
 #ifndef WIN32
 /*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,11 @@ if(ENABLE_IPV6_TESTS)
   set_tests_properties(ct_connection_ipv6 PROPERTIES LABELS "CT")
 endif()
 
+add_executable(ct_out_of_memory_handling ct_out_of_memory_handling.c)
+target_link_libraries(ct_out_of_memory_handling hiredis_cluster hiredis ${SSL_LIBRARY})
+add_test(NAME ct_out_of_memory_handling COMMAND "$<TARGET_FILE:ct_out_of_memory_handling>")
+set_tests_properties(ct_out_of_memory_handling PROPERTIES LABELS "CT")
+
 if(ENABLE_SSL)
   # Executable: tls
   add_executable(example_tls main_tls.c)

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -1,0 +1,216 @@
+#include "hircluster.h"
+#include "test_utils.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CLUSTER_NODE "127.0.0.1:7000"
+
+// A OOM failing malloc()
+static void *hi_malloc_fail(size_t size) {
+    UNUSED(size);
+    return NULL;
+}
+
+// A OOM failing calloc()
+static void *hi_calloc_fail(size_t nmemb, size_t size) {
+    UNUSED(nmemb);
+    UNUSED(size);
+    return NULL;
+}
+
+// A OOM failing realloc()
+static void *hi_realloc_fail(void *ptr, size_t size) {
+    UNUSED(ptr);
+    UNUSED(size);
+    return NULL;
+}
+
+// Reset the error string (between tests)
+void reset_cluster_errors(redisClusterContext *cc) {
+    cc->err = 0;
+    memset(cc->errstr, '\0', strlen(cc->errstr));
+}
+
+// Test OOM handling in first allocation in:
+// redisClusterContextInit();
+void test_context_init() {
+    hiredisAllocFuncs ha = {
+        .mallocFn = hi_malloc_fail,
+        .callocFn = hi_calloc_fail,
+        .reallocFn = hi_realloc_fail,
+        .strdupFn = strdup,
+        .freeFn = free,
+    };
+
+    // Override allocators
+    hiredisSetAllocators(&ha);
+    {
+        redisClusterContext *cc = redisClusterContextInit();
+        assert(cc == NULL);
+    }
+    hiredisResetAllocators();
+}
+
+// Test OOM handling in first allocation in:
+// redisClusterSetOptionXXXX
+void test_setoptions() {
+    hiredisAllocFuncs ha = {
+        .mallocFn = hi_malloc_fail,
+        .callocFn = hi_calloc_fail,
+        .reallocFn = hi_realloc_fail,
+        .strdupFn = strdup,
+        .freeFn = free,
+    };
+
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    ASSERT_STR_EQ(cc->errstr, "");
+
+    // Override allocators
+    hiredisSetAllocators(&ha);
+    {
+        int result;
+        result = redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+        assert(result == REDIS_ERR);
+        ASSERT_STR_STARTS_WITH(cc->errstr, "servers address is error");
+
+        reset_cluster_errors(cc);
+
+        result = redisClusterSetOptionAddNode(cc, CLUSTER_NODE);
+        assert(result == REDIS_ERR);
+        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+
+        reset_cluster_errors(cc);
+
+        struct timeval timeout = {0, 500000};
+        result = redisClusterSetOptionConnectTimeout(cc, timeout);
+        assert(result == REDIS_ERR);
+        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+
+        reset_cluster_errors(cc);
+
+        result = redisClusterSetOptionTimeout(cc, timeout);
+        assert(result == REDIS_ERR);
+        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+    }
+    hiredisResetAllocators();
+
+    redisClusterFree(cc);
+}
+
+// Test OOM handling in first allocation in:
+// redisClusterConnect2()
+void test_cluster_connect() {
+    hiredisAllocFuncs ha = {
+        .mallocFn = hi_malloc_fail,
+        .callocFn = hi_calloc_fail,
+        .reallocFn = hi_realloc_fail,
+        .strdupFn = strdup,
+        .freeFn = free,
+    };
+    struct timeval timeout = {0, 500000};
+
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+    redisClusterSetOptionConnectTimeout(cc, timeout);
+    ASSERT_STR_EQ(cc->errstr, "");
+
+    // Override allocators
+    hiredisSetAllocators(&ha);
+    {
+        int result;
+        result = redisClusterConnect2(cc);
+        assert(result == REDIS_ERR);
+        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+    }
+    hiredisResetAllocators();
+
+    redisClusterFree(cc);
+}
+
+// Test OOM handling in first allocation in:
+// redisClusterCommand()
+void test_cluster_command() {
+    hiredisAllocFuncs ha = {
+        .mallocFn = hi_malloc_fail,
+        .callocFn = hi_calloc_fail,
+        .reallocFn = hi_realloc_fail,
+        .strdupFn = strdup,
+        .freeFn = free,
+    };
+
+    struct timeval timeout = {0, 500000};
+
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+    redisClusterSetOptionConnectTimeout(cc, timeout);
+
+    int result;
+    result = redisClusterConnect2(cc);
+    ASSERT_MSG(result == REDIS_OK, cc->errstr);
+    ASSERT_STR_EQ(cc->errstr, "");
+
+    // Override allocators
+    hiredisSetAllocators(&ha);
+    {
+        redisReply *reply;
+        reply = (redisReply *)redisClusterCommand(cc, "SET key value");
+        assert(reply == NULL);
+
+        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+    }
+    hiredisResetAllocators();
+
+    redisClusterFree(cc);
+}
+
+// Test OOM handling in first allocation in:
+// redisClusterAppendCommand()
+void test_cluster_append_command() {
+    hiredisAllocFuncs ha = {
+        .mallocFn = hi_malloc_fail,
+        .callocFn = hi_calloc_fail,
+        .reallocFn = hi_realloc_fail,
+        .strdupFn = strdup,
+        .freeFn = free,
+    };
+
+    struct timeval timeout = {0, 500000};
+
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+    redisClusterSetOptionConnectTimeout(cc, timeout);
+
+    int result;
+    result = redisClusterConnect2(cc);
+    ASSERT_MSG(result == REDIS_OK, cc->errstr);
+    ASSERT_STR_EQ(cc->errstr, "");
+
+    // Override allocators
+    hiredisSetAllocators(&ha);
+    {
+        result = redisClusterAppendCommand(cc, "SET foo one");
+        assert(result == REDIS_ERR);
+        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+    }
+    hiredisResetAllocators();
+
+    redisClusterFree(cc);
+}
+
+int main() {
+    // Test the handling of an out-of-memory situation
+    // in the first allocation done in the API functions.
+    test_context_init();
+    test_setoptions();
+    test_cluster_connect();
+    test_cluster_command();
+    test_cluster_append_command();
+
+    return 0;
+}

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -7,35 +7,49 @@
 
 #define CLUSTER_NODE "127.0.0.1:7000"
 
-// A OOM failing malloc()
+int successfulAllocations = 0;
+
+// A configurable OOM failing malloc()
 static void *hi_malloc_fail(size_t size) {
-    UNUSED(size);
+    if (successfulAllocations > 0) {
+        --successfulAllocations;
+        return malloc(size);
+    }
     return NULL;
 }
 
-// A OOM failing calloc()
+// A  configurable OOM failing calloc()
 static void *hi_calloc_fail(size_t nmemb, size_t size) {
-    UNUSED(nmemb);
-    UNUSED(size);
+    if (successfulAllocations > 0) {
+        --successfulAllocations;
+        return calloc(nmemb, size);
+    }
     return NULL;
 }
 
-// A OOM failing realloc()
+// A  configurable OOM failing realloc()
 static void *hi_realloc_fail(void *ptr, size_t size) {
-    UNUSED(ptr);
-    UNUSED(size);
+    if (successfulAllocations > 0) {
+        --successfulAllocations;
+        return realloc(ptr, size);
+    }
     return NULL;
 }
 
-// Reset the error string (between tests)
-void reset_cluster_errors(redisClusterContext *cc) {
+void prepare_allocation_test(redisClusterContext *cc,
+                             int _successfulAllocations) {
+    successfulAllocations = _successfulAllocations;
     cc->err = 0;
     memset(cc->errstr, '\0', strlen(cc->errstr));
 }
 
-// Test OOM handling in first allocation in:
-// redisClusterContextInit();
-void test_context_init() {
+// Test of allocation handling
+// The testcase will trigger allocation failures during API calls.
+// It will start by triggering an allocation fault, and the next iteration
+// will start with an successfull allocation and then a failing one,
+// next iteration 2 successful and one failing allocation, and so on..
+void test_cluster_communication() {
+    int result;
     hiredisAllocFuncs ha = {
         .mallocFn = hi_malloc_fail,
         .callocFn = hi_calloc_fail,
@@ -43,174 +57,100 @@ void test_context_init() {
         .strdupFn = strdup,
         .freeFn = free,
     };
-
     // Override allocators
     hiredisSetAllocators(&ha);
+
+    // Context init
+    redisClusterContext *cc;
     {
-        redisClusterContext *cc = redisClusterContextInit();
+        successfulAllocations = 0;
+        cc = redisClusterContextInit();
         assert(cc == NULL);
+
+        successfulAllocations = 1;
+        cc = redisClusterContextInit();
+        assert(cc);
     }
-    hiredisResetAllocators();
-}
 
-// Test OOM handling in first allocation in:
-// redisClusterSetOptionXXXX
-void test_setoptions() {
-    hiredisAllocFuncs ha = {
-        .mallocFn = hi_malloc_fail,
-        .callocFn = hi_calloc_fail,
-        .reallocFn = hi_realloc_fail,
-        .strdupFn = strdup,
-        .freeFn = free,
-    };
-
-    redisClusterContext *cc = redisClusterContextInit();
-    assert(cc);
-    ASSERT_STR_EQ(cc->errstr, "");
-
-    // Override allocators
-    hiredisSetAllocators(&ha);
+    // Add nodes
     {
-        int result;
+        for (int i = 0; i < 9; ++i) {
+            prepare_allocation_test(cc, i);
+            result = redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+            assert(result == REDIS_ERR);
+            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        }
+
+        prepare_allocation_test(cc, 9);
         result = redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
-        assert(result == REDIS_ERR);
-        ASSERT_STR_STARTS_WITH(cc->errstr, "servers address is error");
+        assert(result == REDIS_OK);
+    }
 
-        reset_cluster_errors(cc);
-
-        result = redisClusterSetOptionAddNode(cc, CLUSTER_NODE);
-        assert(result == REDIS_ERR);
-        ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
-        reset_cluster_errors(cc);
-
+    // Set timeout
+    {
         struct timeval timeout = {0, 500000};
+
+        prepare_allocation_test(cc, 0);
         result = redisClusterSetOptionConnectTimeout(cc, timeout);
         assert(result == REDIS_ERR);
         ASSERT_STR_EQ(cc->errstr, "Out of memory");
 
-        reset_cluster_errors(cc);
-
-        result = redisClusterSetOptionTimeout(cc, timeout);
-        assert(result == REDIS_ERR);
-        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        prepare_allocation_test(cc, 1);
+        result = redisClusterSetOptionConnectTimeout(cc, timeout);
+        assert(result == REDIS_OK);
     }
-    hiredisResetAllocators();
 
-    redisClusterFree(cc);
-}
-
-// Test OOM handling in first allocation in:
-// redisClusterConnect2()
-void test_cluster_connect() {
-    hiredisAllocFuncs ha = {
-        .mallocFn = hi_malloc_fail,
-        .callocFn = hi_calloc_fail,
-        .reallocFn = hi_realloc_fail,
-        .strdupFn = strdup,
-        .freeFn = free,
-    };
-    struct timeval timeout = {0, 500000};
-
-    redisClusterContext *cc = redisClusterContextInit();
-    assert(cc);
-    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
-    redisClusterSetOptionConnectTimeout(cc, timeout);
-    ASSERT_STR_EQ(cc->errstr, "");
-
-    // Override allocators
-    hiredisSetAllocators(&ha);
+    // Connect
     {
-        int result;
+        for (int i = 0; i < 133; ++i) {
+            prepare_allocation_test(cc, i);
+            result = redisClusterConnect2(cc);
+            assert(result == REDIS_ERR);
+        }
+
+        prepare_allocation_test(cc, 133);
         result = redisClusterConnect2(cc);
-        assert(result == REDIS_ERR);
-        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        assert(result == REDIS_OK);
     }
-    hiredisResetAllocators();
 
-    redisClusterFree(cc);
-}
-
-// Test OOM handling in first allocation in:
-// redisClusterCommand()
-void test_cluster_command() {
-    hiredisAllocFuncs ha = {
-        .mallocFn = hi_malloc_fail,
-        .callocFn = hi_calloc_fail,
-        .reallocFn = hi_realloc_fail,
-        .strdupFn = strdup,
-        .freeFn = free,
-    };
-
-    struct timeval timeout = {0, 500000};
-
-    redisClusterContext *cc = redisClusterContextInit();
-    assert(cc);
-    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
-    redisClusterSetOptionConnectTimeout(cc, timeout);
-
-    int result;
-    result = redisClusterConnect2(cc);
-    ASSERT_MSG(result == REDIS_OK, cc->errstr);
-    ASSERT_STR_EQ(cc->errstr, "");
-
-    // Override allocators
-    hiredisSetAllocators(&ha);
+    // Command
     {
         redisReply *reply;
+
+        for (int i = 0; i < 36; ++i) {
+            prepare_allocation_test(cc, 0 + i);
+            reply = (redisReply *)redisClusterCommand(cc, "SET key value");
+            assert(reply == NULL);
+            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        }
+
+        prepare_allocation_test(cc, 36);
         reply = (redisReply *)redisClusterCommand(cc, "SET key value");
-        assert(reply == NULL);
-
-        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        CHECK_REPLY_OK(cc, reply);
+        freeReplyObject(reply);
     }
-    hiredisResetAllocators();
 
-    redisClusterFree(cc);
-}
-
-// Test OOM handling in first allocation in:
-// redisClusterAppendCommand()
-void test_cluster_append_command() {
-    hiredisAllocFuncs ha = {
-        .mallocFn = hi_malloc_fail,
-        .callocFn = hi_calloc_fail,
-        .reallocFn = hi_realloc_fail,
-        .strdupFn = strdup,
-        .freeFn = free,
-    };
-
-    struct timeval timeout = {0, 500000};
-
-    redisClusterContext *cc = redisClusterContextInit();
-    assert(cc);
-    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
-    redisClusterSetOptionConnectTimeout(cc, timeout);
-
-    int result;
-    result = redisClusterConnect2(cc);
-    ASSERT_MSG(result == REDIS_OK, cc->errstr);
-    ASSERT_STR_EQ(cc->errstr, "");
-
-    // Override allocators
-    hiredisSetAllocators(&ha);
+    // Append command
     {
+        for (int i = 0; i < 33; ++i) {
+            prepare_allocation_test(cc, 0 + i);
+            result = redisClusterAppendCommand(cc, "SET foo one");
+            assert(result == REDIS_ERR);
+            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        }
+
+        prepare_allocation_test(cc, 33);
         result = redisClusterAppendCommand(cc, "SET foo one");
-        assert(result == REDIS_ERR);
-        ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        assert(result == REDIS_OK);
     }
-    hiredisResetAllocators();
 
     redisClusterFree(cc);
+    hiredisResetAllocators();
 }
 
 int main() {
-    // Test the handling of an out-of-memory situation
-    // in the first allocation done in the API functions.
-    test_context_init();
-    test_setoptions();
-    test_cluster_connect();
-    test_cluster_command();
-    test_cluster_append_command();
+
+    test_cluster_communication();
 
     return 0;
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -57,4 +57,10 @@
                    _ctx->errstr);                                              \
     }
 
+#define ASSERT_STR_EQ(_s1, _s2)                                                \
+    { assert(strcmp(_s1, _s2) == 0); }
+
+#define ASSERT_STR_STARTS_WITH(_s1, _s2)                                       \
+    { assert(strncmp(_s1, _s2, strlen(_s2)) == 0); }
+
 #endif

--- a/win32.h
+++ b/win32.h
@@ -8,10 +8,6 @@
 #define inline __inline
 #endif
 
-#ifndef strdup
-#define strdup _strdup
-#endif
-
 #ifndef strcasecmp
 #define strcasecmp _stricmp
 #endif


### PR DESCRIPTION
This PR handles vipshop/hiredis-vip#136 and the vulnerability report regarding handling failing allocations, see https://nvd.nist.gov/vuln/detail/CVE-2020-7105
* Allocation results are now checked before the memory is used.
* This PR also replaces existing allocation/free macros to use the same api as hiredis

Some details:
Hiredis uses its own allocator-functions which by default uses libc.
By using the same design in hiredis-cluster a user can replace the
allocator for both hiredis and hiredis-cluster at the same time.

Own allocator functions can be enabled by the API:
 `hiredisAllocFuncs hiredisSetAllocators(hiredisAllocFuncs *ha)`