### PR TITLE
Add alternative makefile and improve examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.Y.Z - Y D, 2021
 * Minimum required version of CMake changed to 3.11 (from 3.14)
+* Improved examples
 
 ### 0.5.0 - Dec 07, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 0.Y.Z - Y D, 2021
 * Minimum required version of CMake changed to 3.11 (from 3.14)
+* Re-added the Makefile for symmetry with hiredis, which also enables
+  support for statically-linked libraries.
 * Improved examples
 
 ### 0.5.0 - Dec 07, 2020

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,138 @@
+# Hiredis-cluster Makefile, based on the Makefile in hiredis.
+#
+# Copyright (C) 2021 Bjorn Svensson <bjorn.a.svensson@est.tech>
+# Copyright (C) 2010-2011 Salvatore Sanfilippo <antirez at gmail dot com>
+# Copyright (C) 2010-2011 Pieter Noordhuis <pcnoordhuis at gmail dot com>
+# This file is released under the BSD license, see the COPYING file
+
+OBJ=adlist.o command.o crc16.o hiarray.o hircluster.o hiutil.o
+EXAMPLES=hiredis-cluster-example hiredis-cluster-example-tls
+LIBNAME=libhiredis_cluster
+PKGCONFNAME=hiredis_cluster.pc
+
+HIREDIS_CLUSTER_MAJOR=$(shell grep HIREDIS_CLUSTER_MAJOR hircluster.h | awk '{print $$3}')
+HIREDIS_CLUSTER_MINOR=$(shell grep HIREDIS_CLUSTER_MINOR hircluster.h | awk '{print $$3}')
+HIREDIS_CLUSTER_PATCH=$(shell grep HIREDIS_CLUSTER_PATCH hircluster.h | awk '{print $$3}')
+HIREDIS_CLUSTER_SONAME=$(shell grep HIREDIS_CLUSTER_SONAME hircluster.h | awk '{print $$3}')
+
+# Installation related variables and target
+PREFIX?=/usr/local
+INCLUDE_PATH?=include/hiredis_cluster
+LIBRARY_PATH?=lib
+PKGCONF_PATH?=pkgconfig
+INSTALL_INCLUDE_PATH= $(DESTDIR)$(PREFIX)/$(INCLUDE_PATH)
+INSTALL_LIBRARY_PATH= $(DESTDIR)$(PREFIX)/$(LIBRARY_PATH)
+INSTALL_PKGCONF_PATH= $(INSTALL_LIBRARY_PATH)/$(PKGCONF_PATH)
+
+# Fallback to gcc when $CC is not in $PATH.
+CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
+OPTIMIZATION?=-O3
+WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
+DEBUG_FLAGS?= -g -ggdb
+REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
+REAL_LDFLAGS=$(LDFLAGS)
+
+DYLIBSUFFIX=so
+STLIBSUFFIX=a
+DYLIB_MINOR_NAME=$(LIBNAME).$(DYLIBSUFFIX).$(HIREDIS_CLUSTER_SONAME)
+DYLIB_MAJOR_NAME=$(LIBNAME).$(DYLIBSUFFIX).$(HIREDIS_CLUSTER_MAJOR)
+DYLIBNAME=$(LIBNAME).$(DYLIBSUFFIX)
+
+DYLIB_MAKE_CMD=$(CC) -shared -Wl,-soname,$(DYLIB_MINOR_NAME)
+STLIBNAME=$(LIBNAME).$(STLIBSUFFIX)
+STLIB_MAKE_CMD=$(AR) rcs
+
+USE_SSL?=0
+
+# Platform-specific overrides
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+
+ifeq ($(USE_SSL),1)
+ifeq ($(uname_S),Linux)
+  REAL_CFLAGS+=-DSSL_SUPPORT
+  REAL_LDFLAGS+=-lssl -lcrypto
+endif
+endif
+
+all: $(DYLIBNAME) $(STLIBNAME) $(PKGCONFNAME)
+
+# Deps (use make dep to generate this)
+adlist.o: adlist.c adlist.h hiutil.h
+command.o: command.c command.h adlist.h hiarray.h hiutil.h
+crc16.o: crc16.c hiutil.h
+dict.o: dict.c dict.h
+hiarray.o: hiarray.c hiarray.h hiutil.h
+hircluster.o: hircluster.c adlist.h command.h dict.c dict.h hiarray.h hircluster.h hiutil.h win32.h
+hiutil.o: hiutil.c hiutil.h win32.h
+
+$(DYLIBNAME): $(OBJ)
+	$(DYLIB_MAKE_CMD) -o $(DYLIBNAME) $(OBJ) $(REAL_LDFLAGS)
+
+$(STLIBNAME): $(OBJ)
+	$(STLIB_MAKE_CMD) $(STLIBNAME) $(OBJ)
+
+dynamic: $(DYLIBNAME)
+static: $(STLIBNAME)
+
+# Binaries:
+hiredis-cluster-example: examples/src/example.c
+	$(CC) -o examples/$@ $(REAL_CFLAGS) $< $(REAL_LDFLAGS)
+hiredis-cluster-example-tls: examples/src/example_tls.c
+	$(CC) -o examples/$@ $(REAL_CFLAGS) $< $(REAL_LDFLAGS)
+
+examples: $(EXAMPLES)
+
+.c.o:
+	$(CC) -std=c99 -pedantic -c $(REAL_CFLAGS) $<
+
+clean:
+	rm -rf $(DYLIBNAME) $(STLIBNAME) $(SSL_DYLIBNAME) $(PKGCONFNAME) examples/hiredis-cluster-example* *.o *.gcda *.gcno *.gcov
+
+dep:
+	$(CC) $(CPPFLAGS) $(CFLAGS) -MM *.c
+
+INSTALL?= cp -pPR
+
+$(PKGCONFNAME): hircluster.h
+	@echo "Generating $@ for pkgconfig..."
+	@echo prefix=$(PREFIX) > $@
+	@echo exec_prefix=\$${prefix} >> $@
+	@echo libdir=$(PREFIX)/$(LIBRARY_PATH) >> $@
+	@echo includedir=$(PREFIX)/$(INCLUDE_PATH) >> $@
+	@echo >> $@
+	@echo Name: hiredis-cluster >> $@
+	@echo Description: Minimalistic C client library for Redis Cluster. >> $@
+	@echo Version: $(HIREDIS_CLUSTER_MAJOR).$(HIREDIS_CLUSTER_MINOR).$(HIREDIS_CLUSTER_PATCH) >> $@
+	@echo Libs: -L\$${libdir} -lhiredis_cluster >> $@
+	@echo Cflags: -I\$${includedir} -D_FILE_OFFSET_BITS=64 >> $@
+
+install: $(DYLIBNAME) $(STLIBNAME) $(PKGCONFNAME)
+	mkdir -p $(INSTALL_INCLUDE_PATH) $(INSTALL_INCLUDE_PATH)/adapters $(INSTALL_LIBRARY_PATH)
+	$(INSTALL) adlist.h dict.h hiarray.h hircluster.h hiutil.h win32.h $(INSTALL_INCLUDE_PATH)
+	$(INSTALL) adapters/*.h $(INSTALL_INCLUDE_PATH)/adapters
+	$(INSTALL) $(DYLIBNAME) $(INSTALL_LIBRARY_PATH)/$(DYLIB_MINOR_NAME)
+	cd $(INSTALL_LIBRARY_PATH) && ln -sf $(DYLIB_MINOR_NAME) $(DYLIBNAME)
+	$(INSTALL) $(STLIBNAME) $(INSTALL_LIBRARY_PATH)
+	mkdir -p $(INSTALL_PKGCONF_PATH)
+	$(INSTALL) $(PKGCONFNAME) $(INSTALL_PKGCONF_PATH)
+
+32bit:
+	@echo ""
+	@echo "WARNING: if this fails under Linux you probably need to install libc6-dev-i386"
+	@echo ""
+	$(MAKE) CFLAGS="-m32" LDFLAGS="-m32"
+
+32bit-vars:
+	$(eval CFLAGS=-m32)
+	$(eval LDFLAGS=-m32)
+
+gprof:
+	$(MAKE) CFLAGS="-pg" LDFLAGS="-pg"
+
+gcov:
+	$(MAKE) CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs"
+
+noopt:
+	$(MAKE) OPTIMIZATION=""
+
+.PHONY: all clean dep install 32bit 32bit-vars gprof gcov noopt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hiredis-cluster is a fork of Hiredis-vip, with the following improvements:
 * Support for SSL/TLS introduced in Redis 6
 * Support for IPv6
 * Support authentication using AUTH
-* Using CMake (3.11+) as build system
+* Uses CMake (3.11+) as the primary build system, but optionally Make can be used directly
 * Code style guide (using clang-format)
 * Improved testing
 * Memory leak corrections and allocation failure handling
@@ -103,6 +103,16 @@ file called `hiredis-config.cmake` will be installed and this contains relevant 
 
 As described in the CMake docs a specific path can be set using a flag like:
 `-Dhiredis_DIR:PATH=${MY_DIR}/hiredis/share/hiredis`
+
+### Alternative build using Makefile directly
+
+When a simpler build setup is preferred a provided Makefile can be used directly
+when building. A benefit of this, instead of using CMake, is that it also provides
+a static library, a similar limitation exists in the CMake files in hiredis v1.0.0.
+
+The only option that exists in the Makefile is to enable SSL/TLS support via `USE_SSL=1`
+
+See `examples/using_make/build.sh` for an example build.
 
 ### Running the tests
 

--- a/examples/src/CMakeLists.txt
+++ b/examples/src/CMakeLists.txt
@@ -1,23 +1,36 @@
 cmake_minimum_required(VERSION 3.14)
-project(examples LANGUAGES CXX)
+project(examples LANGUAGES C)
 
 # Handle libevent and hiredis
 find_library(EVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
 find_package(hiredis REQUIRED)
+find_package(hiredis_ssl REQUIRED)
 find_package(hiredis_cluster REQUIRED)
+
+add_definitions(-DSSL_SUPPORT)
 
 include_directories("${hiredis_INCLUDE_DIRS}")
 include_directories("${hiredis_cluster_INCLUDE_DIRS}")
 
 # Executable: IPv4
-add_executable(example_ipv4 main.cpp)
+add_executable(example_ipv4 example.c)
 target_link_libraries(example_ipv4
   ${hiredis_LIBRARIES}
-  ${hiredis_cluster_LIBRARIES})
+  ${hiredis_cluster_LIBRARIES}
+  ${hiredis_ssl_LIBRARIES})
 
 # Executable: async
-add_executable(example_async main_async.cpp)
+add_executable(example_async example_async.c)
 target_link_libraries(example_async
   ${hiredis_LIBRARIES}
   ${hiredis_cluster_LIBRARIES}
+  ${hiredis_ssl_LIBRARIES}
+  ${EVENT_LIBRARY})
+
+# Executable: tls
+add_executable(example_tls example_tls.c)
+target_link_libraries(example_tls
+  ${hiredis_LIBRARIES}
+  ${hiredis_cluster_LIBRARIES}
+  ${hiredis_ssl_LIBRARIES}
   ${EVENT_LIBRARY})

--- a/examples/src/example.c
+++ b/examples/src/example.c
@@ -1,0 +1,32 @@
+#include "hiredis_cluster/hircluster.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    UNUSED(argc);
+    UNUSED(argv);
+    struct timeval timeout = {1, 500000}; // 1.5s
+
+    redisClusterContext *cc = redisClusterContextInit();
+    redisClusterSetOptionAddNodes(cc, "127.0.0.1:7000");
+    redisClusterSetOptionConnectTimeout(cc, timeout);
+    redisClusterSetOptionRouteUseSlots(cc);
+    redisClusterConnect2(cc);
+    if (cc && cc->err) {
+        printf("Error: %s\n", cc->errstr);
+        // handle error
+        exit(-1);
+    }
+
+    redisReply *reply =
+        (redisReply *)redisClusterCommand(cc, "SET %s %s", "key", "value");
+    printf("SET: %s\n", reply->str);
+    freeReplyObject(reply);
+
+    redisReply *reply2 = (redisReply *)redisClusterCommand(cc, "GET %s", "key");
+    printf("GET: %s\n", reply2->str);
+    freeReplyObject(reply2);
+
+    redisClusterFree(cc);
+    return 0;
+}

--- a/examples/src/example_async.c
+++ b/examples/src/example_async.c
@@ -47,7 +47,7 @@ void disconnectCallback(const redisAsyncContext *ac, int status) {
 int main(int argc, char **argv) {
     printf("Connecting...\n");
     redisClusterAsyncContext *cc =
-        redisClusterAsyncConnect("127.0.0.1:30001", HIRCLUSTER_FLAG_NULL);
+        redisClusterAsyncConnect("127.0.0.1:7000", HIRCLUSTER_FLAG_NULL);
     if (cc && cc->err) {
         printf("Error: %s\n", cc->errstr);
         return 1;

--- a/examples/src/example_tls.c
+++ b/examples/src/example_tls.c
@@ -1,14 +1,34 @@
 #include "hiredis_cluster/hircluster.h"
+
+#include "hiredis/hiredis_ssl.h"
 #include <stdio.h>
 #include <stdlib.h>
 
+#define CLUSTER_NODE_TLS "127.0.0.1:7301"
+
 int main(int argc, char **argv) {
+    UNUSED(argc);
+    UNUSED(argv);
+
+    redisSSLContext *ssl;
+    redisSSLContextError ssl_error;
+
+    redisInitOpenSSL();
+    ssl = redisCreateSSLContext("ca.crt", NULL, "client.crt", "client.key",
+                                NULL, &ssl_error);
+    if (!ssl) {
+        printf("SSL Context error: %s\n", redisSSLContextGetError(ssl_error));
+        exit(1);
+    }
+
     struct timeval timeout = {1, 500000}; // 1.5s
 
     redisClusterContext *cc = redisClusterContextInit();
-    redisClusterSetOptionAddNodes(cc, "127.0.0.1:30001");
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_TLS);
     redisClusterSetOptionConnectTimeout(cc, timeout);
     redisClusterSetOptionRouteUseSlots(cc);
+    redisClusterSetOptionParseSlaves(cc);
+    redisClusterSetOptionEnableSSL(cc, ssl);
     redisClusterConnect2(cc);
     if (cc && cc->err) {
         printf("Error: %s\n", cc->errstr);
@@ -18,13 +38,22 @@ int main(int argc, char **argv) {
 
     redisReply *reply =
         (redisReply *)redisClusterCommand(cc, "SET %s %s", "key", "value");
+    if (!reply) {
+        printf("Reply missing: %s\n", cc->errstr);
+        exit(-1);
+    }
     printf("SET: %s\n", reply->str);
     freeReplyObject(reply);
 
     redisReply *reply2 = (redisReply *)redisClusterCommand(cc, "GET %s", "key");
+    if (!reply2) {
+        printf("Reply missing: %s\n", cc->errstr);
+        exit(-1);
+    }
     printf("GET: %s\n", reply2->str);
     freeReplyObject(reply2);
 
     redisClusterFree(cc);
+    redisFreeSSLContext(ssl);
     return 0;
 }

--- a/examples/using_cmake_externalproject/CMakeLists.txt
+++ b/examples/using_cmake_externalproject/CMakeLists.txt
@@ -7,31 +7,34 @@ ExternalProject_Add(hiredis
   GIT_REPOSITORY  https://github.com/redis/hiredis
   GIT_TAG         v1.0.0
   CMAKE_CACHE_ARGS
-    "-DENABLE_SSL:BOOL=OFF"
+    "-DENABLE_SSL:BOOL=ON"
     "-DCMAKE_BUILD_TYPE:STRING=Debug"
     "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis"
 )
 
 ExternalProject_Add(hiredis_cluster
   PREFIX hiredis_cluster
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.."
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.."
   CMAKE_CACHE_ARGS
-    "-DENABLE_SSL:BOOL=OFF"
+    "-DENABLE_SSL:BOOL=ON"
     "-DDISABLE_TESTS:BOOL=ON"
+    "-DDOWNLOAD_HIREDIS:BOOL=OFF"
     "-DCMAKE_BUILD_TYPE:STRING=Debug"
     "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis_cluster"
     "-Dhiredis_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis/share/hiredis"
+    "-Dhiredis_ssl_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis/share/hiredis_ssl"
   DEPENDS hiredis
 )
 
 ExternalProject_Add(examples
   PREFIX examples
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src"
   INSTALL_COMMAND ""
   CMAKE_CACHE_ARGS
     "-DCMAKE_BUILD_TYPE:STRING=Debug"
     "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/examples"
     "-Dhiredis_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis/share/hiredis"
+    "-Dhiredis_ssl_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis/share/hiredis_ssl"
     "-Dhiredis_cluster_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis_cluster/share/hiredis_cluster"
   DEPENDS hiredis_cluster
 )

--- a/examples/using_cmake_externalproject/build.sh
+++ b/examples/using_cmake_externalproject/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+script_dir=$(realpath "${0%/*}")
+
+# Create build directory
+mkdir -p ${script_dir}/build
+
+# Generate makefiles
+cmake -B ${script_dir}/build -S ${script_dir}
+
+# Build
+VERBOSE=1 make -C ${script_dir}/build

--- a/examples/using_cmake_separate/build.sh
+++ b/examples/using_cmake_separate/build.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+script_dir=$(realpath "${0%/*}")
+
+# Download hiredis
+hiredis_version=1.0.0
+curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
+
+# Build and install hiredis using CMake
+mkdir -p ${script_dir}/hiredis_build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_TESTS=ON -DENABLE_SSL=ON \
+      -DCMAKE_C_FLAGS="-std=c99" \
+      -S ${script_dir}/hiredis-${hiredis_version} -B ${script_dir}/hiredis_build
+make -C ${script_dir}/hiredis_build DESTDIR=${script_dir}/install install
+
+
+# Download hiredis-cluster
+hiredis_cluster_version=0.5.0
+curl -L https://github.com/Nordix/hiredis-cluster/archive/${hiredis_cluster_version}.tar.gz | tar -xz -C ${script_dir}
+
+# Build and install hiredis-cluster using CMake
+# Uses '-Dxxxx_DIR' defines that points to hiredis-config.cmake and hiredis_ssl-config.cmake installed
+# above. These files describes the dependecy packages.
+mkdir -p ${script_dir}/hiredis_cluster_build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_TESTS=ON -DENABLE_SSL=ON -DDOWNLOAD_HIREDIS=OFF \
+      -DCMAKE_C_FLAGS="-std=c99 -D_XOPEN_SOURCE=600" \
+      -Dhiredis_DIR=${script_dir}/install/usr/local/share/hiredis \
+      -Dhiredis_ssl_DIR=${script_dir}/install/usr/local/share/hiredis_ssl \
+      -S ${script_dir}/hiredis-cluster-${hiredis_cluster_version} -B ${script_dir}/hiredis_cluster_build
+make -C ${script_dir}/hiredis_cluster_build DESTDIR=${script_dir}/install install
+
+
+# Build examples from this repo. but link with above built libraries
+# installed in ${script_dir}/install/
+mkdir -p ${script_dir}/example_build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_C_FLAGS="-std=c99" \
+      -Dhiredis_DIR=${script_dir}/install/usr/local/share/hiredis \
+      -Dhiredis_ssl_DIR=${script_dir}/install/usr/local/share/hiredis_ssl \
+      -Dhiredis_cluster_DIR=${script_dir}/install/usr/local/share/hiredis_cluster \
+      -S ${script_dir}/../src -B ${script_dir}/example_build
+make -C ${script_dir}/example_build

--- a/examples/using_make/build.sh
+++ b/examples/using_make/build.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -e
+
+# This script builds hiredis and hiredis-cluster using Make directly.
+# The static library variants are used when building the examples.
+
+script_dir=$(realpath "${0%/*}")
+repo_dir=$(realpath "${script_dir}/../../")
+
+# Download hiredis
+hiredis_version=1.0.0
+curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
+
+# Build and install hiredis using Make
+make -C ${script_dir}/hiredis-${hiredis_version} DESTDIR=${script_dir}/install USE_SSL=1 all install
+
+
+# Download hiredis-cluster
+hiredis_cluster_version=0.5.0
+curl -L https://github.com/Nordix/hiredis-cluster/archive/${hiredis_cluster_version}.tar.gz | tar -xz -C ${script_dir}
+
+# Copy makefile since its not available in v0.5.0
+cp ${repo_dir}/Makefile ${script_dir}/hiredis-cluster-${hiredis_cluster_version}/
+
+# Build and install hiredis-cluster using Make
+make -C ${script_dir}/hiredis-cluster-${hiredis_cluster_version} \
+     CFLAGS="-I${script_dir}/install/usr/local/include -D_XOPEN_SOURCE=600" LDFLAGS="-L${script_dir}/install/usr/local/lib" USE_SSL=1 clean all
+make -C ${script_dir}/hiredis-cluster-${hiredis_cluster_version} \
+     DESTDIR=${script_dir}/install install
+
+
+# Build example binaries by providing static libraries
+make -C ${repo_dir} CFLAGS="-I${script_dir}/install/usr/local/include" \
+     LDFLAGS="${script_dir}/install/usr/local/lib/libhiredis_cluster.a ${script_dir}/install/usr/local/lib/libhiredis.a ${script_dir}/install/usr/local/lib/libhiredis_ssl.a" \
+     USE_SSL=1 clean examples
+
+
+# Run simple example:
+# ./examples/hiredis-cluster-example
+#
+# To get a simple Redis Cluster to run towards:
+# docker run --name docker-cluster -d -p 7000-7006:7000-7006 "bjosv/redis-cluster:latest"
+#
+
+# Run TLS/SSL example:
+# ./examples/hiredis-cluster-example-tls
+#
+# Prepare a Redis Cluster to run towards:
+# openssl genrsa -out ca.key 4096
+# openssl req -x509 -new -nodes -sha256 -key ca.key -days 3650 -subj '/CN=Redis Test CA' -out ca.crt
+# openssl genrsa -out redis.key 2048
+# openssl req -new -sha256 -key redis.key -subj '/CN=Redis Server Test Cert' | openssl x509 -req -sha256 -CA ca.crt -CAkey ca.key -CAserial ca.txt -CAcreateserial -days 365 -out redis.crt
+# openssl genrsa -out client.key 2048
+# openssl req -new -sha256 -key client.key -subj '/CN=Redis Client Test Cert' | openssl x509 -req -sha256 -CA ca.crt -CAkey ca.key -CAserial ca.txt -CAcreateserial -days 365 -out client.crt
+#
+# chmod 777 redis.key
+#
+# docker run --name redis-tls-1 -d --net=host -v $PWD:/tls:ro redis:6.0.9 redis-server --cluster-enabled yes --tls-cluster yes --port 0 --tls-ca-cert-file /tls/ca.crt --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-port 7301
+# docker run --name redis-tls-2 -d --net=host -v $PWD:/tls:ro redis:6.0.9 redis-server --cluster-enabled yes --tls-cluster yes --port 0 --tls-ca-cert-file /tls/ca.crt --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-port 7302
+# docker run --name redis-tls-3 -d --net=host -v $PWD:/tls:ro redis:6.0.9 redis-server --cluster-enabled yes --tls-cluster yes --port 0 --tls-ca-cert-file /tls/ca.crt --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-port 7303
+# docker run --name redis-tls-4 -d --net=host -v $PWD:/tls:ro redis:6.0.9 redis-server --cluster-enabled yes --tls-cluster yes --port 0 --tls-ca-cert-file /tls/ca.crt --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-port 7304
+# docker run --name redis-tls-5 -d --net=host -v $PWD:/tls:ro redis:6.0.9 redis-server --cluster-enabled yes --tls-cluster yes --port 0 --tls-ca-cert-file /tls/ca.crt --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-port 7305
+# docker run --name redis-tls-6 -d --net=host -v $PWD:/tls:ro redis:6.0.9 redis-server --cluster-enabled yes --tls-cluster yes --port 0 --tls-ca-cert-file /tls/ca.crt --tls-cert-file /tls/redis.crt --tls-key-file /tls/redis.key --tls-port 7306
+#
+# echo 'yes' | docker run --name redis-cli-tls -i --rm --net=host -v $PWD:/tls:ro redis:6.0.9 redis-cli --cluster create --tls --cacert /tls/ca.crt --cert /tls/redis.crt --key /tls/redis.key 127.0.0.1:7301 127.0.0.1:7302 127.0.0.1:7303 127.0.0.1:7304 127.0.0.1:7305 127.0.0.1:7306 --cluster-replicas 1


### PR DESCRIPTION
A simplified Makefile is added as an alternative to the preferred CMake.
This enables users to choose, just like its done in hiredis.
The current benefit of the provided Makefile, both in hiredis and
hiredis-cluster, is that statically linked libraries can be built.
This is not supported by CMake build in the dependency hiredis v1.0.0.

The examples how to build are improved with setup.sh scripts.
These are working examples that can be used a base for user projects.