### PR TITLE
Add test coverage support in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(DOWNLOAD_HIREDIS  "Download the dependency hiredis from GitHub" ON)
 option(ENABLE_SSL        "Enable SSL/TLS support" OFF)
 option(DISABLE_TESTS     "Disable compilation of test" OFF)
 option(ENABLE_IPV6_TESTS "Enable IPv6 tests requiring special prerequisites" OFF)
+option(ENABLE_COVERAGE   "Enable test coverage reporting" OFF)
 
 macro(getVersionBit name)
   set(VERSION_REGEX "^#define ${name} (.+)$")
@@ -31,7 +32,12 @@ set(CMAKE_C_STANDARD 99)
 
 # Build using a sanitizer
 if(USE_SANITIZER)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=${USE_SANITIZER}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=${USE_SANITIZER}")
+endif()
+
+if(ENABLE_COVERAGE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -O0" )
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage" )
 endif()
 
 SET(hiredis_cluster_sources
@@ -138,6 +144,18 @@ file(GLOB_RECURSE FILES_TO_FORMAT
 add_custom_target(format
   COMMAND ${CLANG_FORMAT} -i ${FILES_TO_FORMAT}
 )
+
+# Code coverage target
+if(ENABLE_COVERAGE)
+  find_program(GCOVR "gcovr")
+
+  add_custom_command(OUTPUT _run_gcovr
+    POST_BUILD
+    COMMAND ${GCOVR} -r ${CMAKE_SOURCE_DIR} --object-dir=${CMAKE_BINARY_DIR} --html-details coverage.html
+    COMMAND echo "Coverage report generated: ${CMAKE_BINARY_DIR}/coverage.html"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  add_custom_target (coverage DEPENDS _run_gcovr)
+endif()
 
 configure_file(hiredis_cluster.pc.in hiredis_cluster.pc @ONLY)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,23 @@ source code by running the following make target in your build directory:
 $ make format
 ```
 
+### Test coverage
+
+Make sure changes are covered by tests.
+Code coverage instrumentation can be enabled using a build option and
+a detailed html report can be viewed using following example:
+
+```sh
+$ mkdir -p build; cd build
+$ cmake -DENABLE_COVERAGE=ON ..
+$ make all test coverage
+$ xdg-open ./coverage.html
+```
+
+The report generation requires that [gcovr](https://gcovr.com/en/stable/index.html)
+is installed in your path. Any reporting tool of choice can be used, as long as
+it reads .gcda and .gcno files created during the test run.
+
 ## Submitting changes
 
 * Run the formatter before committing when contributing to this project (`make format`).

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ The following CMake options are available:
   * `OFF` (default)
   * `ON` Enable IPv6 tests. Requires that IPv6 is
     [setup](https://docs.docker.com/config/daemon/ipv6/) in Docker.
+* `ENABLE_COVERAGE`
+  * `OFF` (default)
+  * `ON` Compile using build flags that enables the GNU coverage tool `gcov`
+    to provide test coverage information. This CMake option also enables a new
+    build target `coverage` to generate a test coverage report using
+    [gcovr](https://gcovr.com/en/stable/index.html).
 * `USE_SANITIZER`
    Compile using a specific sanitizer that detect issues. The value of this
    option specifies which sanitizer to activate, but it depends on support in the


### PR DESCRIPTION
A new build option is added `ENABLE_COVERAGE=ON`:
Compile using build flags that enables the GNU coverage tool `gcov`
to provide test coverage information. This CMake option also enables a new
build target `coverage` to generate a test coverage report using `gcovr`.

Example:
$ cmake -DENABLE_COVERAGE=ON ..
$ make all test coverage
$ xdg-open ./coverage.html