### PR TITLE
Cleanup of dict and list iterators

### DIFF
--- a/adlist.c
+++ b/adlist.c
@@ -236,7 +236,7 @@ listNode *listNext(listIter *iter) {
  * The original list both on success or error is never modified. */
 hilist *listDup(hilist *orig) {
     hilist *copy;
-    listIter *iter;
+    listIter iter;
     listNode *node;
 
     if ((copy = listCreate()) == NULL)
@@ -244,26 +244,23 @@ hilist *listDup(hilist *orig) {
     copy->dup = orig->dup;
     copy->free = orig->free;
     copy->match = orig->match;
-    iter = listGetIterator(orig, AL_START_HEAD);
-    while ((node = listNext(iter)) != NULL) {
+    listRewind(orig, &iter);
+    while ((node = listNext(&iter)) != NULL) {
         void *value;
 
         if (copy->dup) {
             value = copy->dup(node->value);
             if (value == NULL) {
                 listRelease(copy);
-                listReleaseIterator(iter);
                 return NULL;
             }
         } else
             value = node->value;
         if (listAddNodeTail(copy, value) == NULL) {
             listRelease(copy);
-            listReleaseIterator(iter);
             return NULL;
         }
     }
-    listReleaseIterator(iter);
     return copy;
 }
 
@@ -277,27 +274,21 @@ hilist *listDup(hilist *orig) {
  * (search starts from head). If no matching node exists
  * NULL is returned. */
 listNode *listSearchKey(hilist *list, void *key) {
-    listIter *iter;
+    listIter iter;
     listNode *node;
 
-    iter = listGetIterator(list, AL_START_HEAD);
-    if (iter == NULL) {
-        return NULL;
-    }
-    while ((node = listNext(iter)) != NULL) {
+    listRewind(list, &iter);
+    while ((node = listNext(&iter)) != NULL) {
         if (list->match) {
             if (list->match(node->value, key)) {
-                listReleaseIterator(iter);
                 return node;
             }
         } else {
             if (key == node->value) {
-                listReleaseIterator(iter);
                 return node;
             }
         }
     }
-    listReleaseIterator(iter);
     return NULL;
 }
 

--- a/dict.c
+++ b/dict.c
@@ -210,16 +210,11 @@ static dictEntry *dictFind(dict *ht, const void *key) {
     return NULL;
 }
 
-static dictIterator *dictGetIterator(dict *ht) {
-    dictIterator *iter = hi_malloc(sizeof(*iter));
-    if (iter == NULL)
-        return NULL;
-
+static void dictInitIterator(dictIterator *iter, dict *ht) {
     iter->ht = ht;
     iter->index = -1;
     iter->entry = NULL;
     iter->nextEntry = NULL;
-    return iter;
 }
 
 static dictEntry *dictNext(dictIterator *iter) {
@@ -241,8 +236,6 @@ static dictEntry *dictNext(dictIterator *iter) {
     }
     return NULL;
 }
-
-static void dictReleaseIterator(dictIterator *iter) { hi_free(iter); }
 
 /* ------------------------- private functions ------------------------------ */
 

--- a/dict.h
+++ b/dict.h
@@ -119,8 +119,7 @@ static int dictExpand(dict *ht, unsigned long size);
 static int dictAdd(dict *ht, void *key, void *val);
 static void dictRelease(dict *ht);
 static dictEntry *dictFind(dict *ht, const void *key);
-static dictIterator *dictGetIterator(dict *ht);
+static void dictInitIterator(dictIterator *iter, dict *ht);
 static dictEntry *dictNext(dictIterator *iter);
-static void dictReleaseIterator(dictIterator *iter);
 
 #endif /* __DICT_H */

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -61,6 +61,11 @@ void prepare_allocation_test_async(redisClusterAsyncContext *acc,
 // It will start by triggering an allocation fault, and the next iteration
 // will start with an successfull allocation and then a failing one,
 // next iteration 2 successful and one failing allocation, and so on..
+//
+// Tip: When this testcase fails after code changes in the library,
+//      use gdb to find out which iteration that fails (print i)
+//      Update i in for-loop and the prepare_allocation_test(_, x) in
+//      the test section just after.
 void test_alloc_failure_handling() {
     int result;
     hiredisAllocFuncs ha = {
@@ -129,13 +134,13 @@ void test_alloc_failure_handling() {
 
     // Connect
     {
-        for (int i = 0; i < 130; ++i) {
+        for (int i = 0; i < 128; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterConnect2(cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(cc, 130);
+        prepare_allocation_test(cc, 128);
         result = redisClusterConnect2(cc);
         assert(result == REDIS_OK);
     }
@@ -335,13 +340,13 @@ void test_alloc_failure_handling_async() {
 
     // Connect
     {
-        for (int i = 0; i < 129; ++i) {
+        for (int i = 0; i < 127; ++i) {
             prepare_allocation_test(acc->cc, i);
             result = redisClusterConnect2(acc->cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(acc->cc, 129);
+        prepare_allocation_test(acc->cc, 127);
         result = redisClusterConnect2(acc->cc);
         assert(result == REDIS_OK);
     }

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -129,13 +129,13 @@ void test_alloc_failure_handling() {
 
     // Connect
     {
-        for (int i = 0; i < 133; ++i) {
+        for (int i = 0; i < 130; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterConnect2(cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(cc, 133);
+        prepare_allocation_test(cc, 130);
         result = redisClusterConnect2(cc);
         assert(result == REDIS_OK);
     }
@@ -163,7 +163,7 @@ void test_alloc_failure_handling() {
         redisReply *reply;
         const char *cmd = "MSET key1 v1 key2 v2 key3 v3";
 
-        for (int i = 0; i < 78; ++i) {
+        for (int i = 0; i < 77; ++i) {
             prepare_allocation_test(cc, i);
             reply = (redisReply *)redisClusterCommand(cc, cmd);
             assert(reply == NULL);
@@ -171,7 +171,7 @@ void test_alloc_failure_handling() {
         }
 
         // Multi-key commands
-        prepare_allocation_test(cc, 78);
+        prepare_allocation_test(cc, 77);
         reply = (redisReply *)redisClusterCommand(cc, cmd);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
@@ -218,15 +218,15 @@ void test_alloc_failure_handling() {
         redisReply *reply;
         const char *cmd = "MSET key1 val1 key2 val2 key3 val3";
 
-        for (int i = 0; i < 70; ++i) {
+        for (int i = 0; i < 69; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterAppendCommand(cc, cmd);
             assert(result == REDIS_ERR);
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
 
-        for (int i = 0; i < 13; ++i) {
-            prepare_allocation_test(cc, 70);
+        for (int i = 0; i < 10; ++i) {
+            prepare_allocation_test(cc, 69);
             result = redisClusterAppendCommand(cc, cmd);
             assert(result == REDIS_OK);
 
@@ -236,11 +236,11 @@ void test_alloc_failure_handling() {
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
 
-        prepare_allocation_test(cc, 70);
+        prepare_allocation_test(cc, 69);
         result = redisClusterAppendCommand(cc, cmd);
         assert(result == REDIS_OK);
 
-        prepare_allocation_test(cc, 13);
+        prepare_allocation_test(cc, 10);
         result = redisClusterGetReply(cc, (void *)&reply);
         assert(result == REDIS_OK);
         CHECK_REPLY_OK(cc, reply);
@@ -335,13 +335,13 @@ void test_alloc_failure_handling_async() {
 
     // Connect
     {
-        for (int i = 0; i < 132; ++i) {
+        for (int i = 0; i < 129; ++i) {
             prepare_allocation_test(acc->cc, i);
             result = redisClusterConnect2(acc->cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(acc->cc, 132);
+        prepare_allocation_test(acc->cc, 129);
         result = redisClusterConnect2(acc->cc);
         assert(result == REDIS_OK);
     }


### PR DESCRIPTION
By replacing the usage of iterator get- & release-functions with init-functions
we can stack allocate list and dict iterators to avoid some costly mallocs.
This also simplifies alternative flows and reduces code.