### PR TITLE
Add API to send commands to a specific node or all nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   support for statically-linked libraries.
 * Improved examples
 * Corrected crashes and leaks in OOM scenarios
+* New API for sending commands to specific node
+* New API for node iteration, can be used for sending commands
+  to some or all nodes.
 
 ### 0.5.0 - Dec 07, 2020
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ SET(hiredis_cluster_sources
     adlist.c
     command.c
     crc16.c
+    dict.c
     hiarray.c
     hircluster.c
     hiutil.c)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Copyright (C) 2010-2011 Pieter Noordhuis <pcnoordhuis at gmail dot com>
 # This file is released under the BSD license, see the COPYING file
 
-OBJ=adlist.o command.o crc16.o hiarray.o hircluster.o hiutil.o
+OBJ=adlist.o command.o crc16.o dict.o hiarray.o hircluster.o hiutil.o
 EXAMPLES=hiredis-cluster-example hiredis-cluster-example-tls
 LIBNAME=libhiredis_cluster
 PKGCONFNAME=hiredis_cluster.pc
@@ -62,7 +62,8 @@ command.o: command.c command.h adlist.h hiarray.h hiutil.h
 crc16.o: crc16.c hiutil.h
 dict.o: dict.c dict.h
 hiarray.o: hiarray.c hiarray.h hiutil.h
-hircluster.o: hircluster.c adlist.h command.h dict.c dict.h hiarray.h hircluster.h hiutil.h win32.h
+hircluster.o: hircluster.c adlist.h command.h dict.h hiarray.h \
+ hircluster.h hiutil.h win32.h
 hiutil.o: hiutil.c hiutil.h win32.h
 
 $(DYLIBNAME): $(OBJ)

--- a/command.c
+++ b/command.c
@@ -1199,6 +1199,7 @@ struct cmd *command_get() {
     command->frag_seq = NULL;
     command->reply = NULL;
     command->sub_commands = NULL;
+    command->node_addr = NULL;
 
     command->keys = hiarray_create(1, sizeof(struct keypos));
     if (command->keys == NULL) {
@@ -1239,6 +1240,11 @@ void command_destroy(struct cmd *command) {
 
     if (command->sub_commands != NULL) {
         listRelease(command->sub_commands);
+    }
+
+    if (command->node_addr != NULL) {
+        sdsfree(command->node_addr);
+        command->node_addr = NULL;
     }
 
     hi_free(command);

--- a/command.h
+++ b/command.h
@@ -159,8 +159,14 @@ struct cmd {
     unsigned quit : 1;      /* quit request? */
     unsigned noforward : 1; /* not need forward (example: ping) */
 
-    int slot_num; /* this command should send to which slot?
-                   * -1:the keys in this command cross different slots*/
+    /* Command destination */
+    int slot_num;    /* Command should be sent to slot.
+                      * Set to -1 if command is sent to a given node,
+                      * or if a slot can not be found or calculated,
+                      * or if its a multi-key command cross different
+                      * nodes (cross slot) */
+    char *node_addr; /* Command sent to this node address */
+
     struct cmd *
         *frag_seq; /* sequence of fragment command, map from keys to fragments*/
 

--- a/dict.c
+++ b/dict.c
@@ -34,9 +34,9 @@
  */
 
 #include <assert.h>
+#include <hiredis/alloc.h>
 #include <limits.h>
 #include <stdlib.h>
-#include <hiredis/alloc.h>
 
 #include "dict.h"
 

--- a/dict.c
+++ b/dict.c
@@ -36,6 +36,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <hiredis/alloc.h>
 
 #include "dict.h"
 
@@ -50,7 +51,7 @@ static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
 
 /* Generic hash function (a popular one from Bernstein).
  * I tested a few and this was the best. */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
+unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
     unsigned int hash = 5381;
 
     while (len--)
@@ -70,7 +71,7 @@ static void _dictReset(dict *ht) {
 }
 
 /* Create a new hash table */
-static dict *dictCreate(dictType *type, void *privDataPtr) {
+dict *dictCreate(dictType *type, void *privDataPtr) {
     dict *ht = hi_malloc(sizeof(*ht));
     if (ht == NULL)
         return NULL;
@@ -88,7 +89,7 @@ static int _dictInit(dict *ht, dictType *type, void *privDataPtr) {
 }
 
 /* Expand or create the hashtable */
-static int dictExpand(dict *ht, unsigned long size) {
+int dictExpand(dict *ht, unsigned long size) {
     dict n; /* the new hashtable */
     unsigned long realsize = _dictNextPower(size), i;
 
@@ -138,7 +139,7 @@ static int dictExpand(dict *ht, unsigned long size) {
 }
 
 /* Add an element to the target hash table */
-static int dictAdd(dict *ht, void *key, void *val) {
+int dictAdd(dict *ht, void *key, void *val) {
     int index;
     dictEntry *entry;
 
@@ -189,12 +190,12 @@ static int _dictClear(dict *ht) {
 }
 
 /* Clear & Release the hash table */
-static void dictRelease(dict *ht) {
+void dictRelease(dict *ht) {
     _dictClear(ht);
     hi_free(ht);
 }
 
-static dictEntry *dictFind(dict *ht, const void *key) {
+dictEntry *dictFind(dict *ht, const void *key) {
     dictEntry *he;
     unsigned int h;
 
@@ -210,14 +211,14 @@ static dictEntry *dictFind(dict *ht, const void *key) {
     return NULL;
 }
 
-static void dictInitIterator(dictIterator *iter, dict *ht) {
+void dictInitIterator(dictIterator *iter, dict *ht) {
     iter->ht = ht;
     iter->index = -1;
     iter->entry = NULL;
     iter->nextEntry = NULL;
 }
 
-static dictEntry *dictNext(dictIterator *iter) {
+dictEntry *dictNext(dictIterator *iter) {
     while (1) {
         if (iter->entry == NULL) {
             iter->index++;

--- a/dict.h
+++ b/dict.h
@@ -113,13 +113,13 @@ typedef struct dictIterator {
 #define dictSize(ht) ((ht)->used)
 
 /* API */
-static unsigned int dictGenHashFunction(const unsigned char *buf, int len);
-static dict *dictCreate(dictType *type, void *privDataPtr);
-static int dictExpand(dict *ht, unsigned long size);
-static int dictAdd(dict *ht, void *key, void *val);
-static void dictRelease(dict *ht);
-static dictEntry *dictFind(dict *ht, const void *key);
-static void dictInitIterator(dictIterator *iter, dict *ht);
-static dictEntry *dictNext(dictIterator *iter);
+unsigned int dictGenHashFunction(const unsigned char *buf, int len);
+dict *dictCreate(dictType *type, void *privDataPtr);
+int dictExpand(dict *ht, unsigned long size);
+int dictAdd(dict *ht, void *key, void *val);
+void dictRelease(dict *ht);
+dictEntry *dictFind(dict *ht, const void *key);
+void dictInitIterator(dictIterator *iter, dict *ht);
+dictEntry *dictNext(dictIterator *iter);
 
 #endif /* __DICT_H */

--- a/hircluster.c
+++ b/hircluster.c
@@ -5,10 +5,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "adlist.h"
 #include "command.h"
-#include "dict.c"
+#include "dict.h"
 #include "hiarray.h"
 #include "hircluster.h"
 #include "hiutil.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,11 @@ target_link_libraries(ct_out_of_memory_handling hiredis_cluster hiredis ${SSL_LI
 add_test(NAME ct_out_of_memory_handling COMMAND "$<TARGET_FILE:ct_out_of_memory_handling>")
 set_tests_properties(ct_out_of_memory_handling PROPERTIES LABELS "CT")
 
+add_executable(ct_specific_nodes ct_specific_nodes.c)
+target_link_libraries(ct_specific_nodes hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+add_test(NAME ct_specific_nodes COMMAND "$<TARGET_FILE:ct_specific_nodes>")
+set_tests_properties(ct_specific_nodes PROPERTIES LABELS "CT")
+
 if(ENABLE_SSL)
   # Executable: tls
   add_executable(example_tls main_tls.c)
@@ -98,6 +103,8 @@ endif()
 # Tests using simulated redis node
 add_executable(clusterclient clusterclient.c)
 target_link_libraries(clusterclient hiredis_cluster hiredis ${SSL_LIBRARY})
+add_executable(clusterclient_all_nodes clusterclient_all_nodes.c)
+target_link_libraries(clusterclient_all_nodes hiredis_cluster hiredis ${SSL_LIBRARY})
 add_executable(clusterclient_async clusterclient_async.c)
 target_link_libraries(clusterclient_async hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
 add_test(NAME set-get-test
@@ -126,3 +133,7 @@ add_test(NAME moved-redirect-test
 #          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/moved-redirect-test.sh"
 #          "$<TARGET_FILE:clusterclient_async>"
 #          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+add_test(NAME dbsize-to-all-nodes-test
+         COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/dbsize-to-all-nodes-test.sh"
+                 "$<TARGET_FILE:clusterclient_all_nodes>"
+                 WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")

--- a/tests/clusterclient_all_nodes.c
+++ b/tests/clusterclient_all_nodes.c
@@ -1,0 +1,75 @@
+/*
+ * This program connects to a cluster and then reads commands from stdin, such
+ * as "DBSIZE", one per line and sends each command to every master node in
+ * the cluster, and prints the results to stdout.
+ */
+
+#include "hircluster.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc <= 1) {
+        fprintf(stderr, "Usage: clusterclient HOST:PORT\n");
+        exit(1);
+    }
+    const char *initnode = argv[1];
+
+    struct timeval timeout = {1, 500000}; // 1.5s
+
+    redisClusterContext *cc = redisClusterContextInit();
+    redisClusterSetOptionAddNodes(cc, initnode);
+    redisClusterSetOptionConnectTimeout(cc, timeout);
+    redisClusterSetOptionRouteUseSlots(cc);
+    redisClusterConnect2(cc);
+    if (cc && cc->err) {
+        fprintf(stderr, "Connect error: %s\n", cc->errstr);
+        exit(100);
+    }
+
+    char command[256];
+    while (fgets(command, 256, stdin)) {
+        if (command[0] == '#')
+            continue; // Skip comments
+
+        size_t len = strlen(command);
+        if (command[len - 1] == '\n') // Chop trailing line break
+            command[len - 1] = '\0';
+
+        nodeIterator ni;
+        initNodeIterator(&ni, cc);
+
+        cluster_node *node;
+        while ((node = nodeNext(&ni)) != NULL) {
+
+            redisReply *reply;
+            reply = redisClusterCommandToNode(cc, node, command);
+            if (!reply || cc->err) {
+                fprintf(stderr, "redisClusterCommand error: %s\n", cc->errstr);
+                exit(101);
+            }
+
+            switch (reply->type) {
+            case REDIS_REPLY_STRING:
+            case REDIS_REPLY_ERROR:
+            case REDIS_REPLY_VERB:
+                printf("%s\n", reply->str);
+                break;
+            case REDIS_REPLY_INTEGER:
+                printf("%lld\n", reply->integer);
+                break;
+            case REDIS_REPLY_ARRAY:
+                printf("ARRAY %ld\n", reply->elements);
+                break;
+            case REDIS_REPLY_DOUBLE:
+                printf("%f\n", reply->dval);
+                break;
+            }
+            freeReplyObject(reply);
+        }
+    }
+
+    redisClusterFree(cc);
+    return 0;
+}

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -1,0 +1,302 @@
+#include "adapters/libevent.h"
+#include "hircluster.h"
+#include "test_utils.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CLUSTER_NODE "127.0.0.1:7000"
+
+void test_command_to_single_node(redisClusterContext *cc) {
+    redisReply *reply;
+
+    dictIterator di;
+    dictInitIterator(&di, cc->nodes);
+
+    dictEntry *de = dictNext(&di);
+    assert(de);
+    cluster_node *node = dictGetEntryVal(de);
+    assert(node);
+
+    reply = redisClusterCommandToNode(cc, node, "DBSIZE");
+    CHECK_REPLY(cc, reply);
+    CHECK_REPLY_TYPE(reply, REDIS_REPLY_INTEGER);
+    freeReplyObject(reply);
+}
+
+void test_command_to_all_nodes(redisClusterContext *cc) {
+
+    nodeIterator ni;
+    initNodeIterator(&ni, cc);
+
+    cluster_node *node;
+    while ((node = nodeNext(&ni)) != NULL) {
+
+        redisReply *reply;
+        reply = redisClusterCommandToNode(cc, node, "DBSIZE");
+        CHECK_REPLY(cc, reply);
+        CHECK_REPLY_TYPE(reply, REDIS_REPLY_INTEGER);
+        freeReplyObject(reply);
+    }
+}
+
+void test_transaction(redisClusterContext *cc) {
+
+    cluster_node *node = redisClusterGetNodeByKey(cc, "foo");
+    assert(node);
+
+    redisReply *reply;
+    reply = redisClusterCommandToNode(cc, node, "MULTI");
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
+    reply = redisClusterCommandToNode(cc, node, "SET foo 99");
+    CHECK_REPLY_QUEUED(cc, reply);
+    freeReplyObject(reply);
+
+    reply = redisClusterCommandToNode(cc, node, "INCR foo");
+    CHECK_REPLY_QUEUED(cc, reply);
+    freeReplyObject(reply);
+
+    reply = redisClusterCommandToNode(cc, node, "EXEC");
+    CHECK_REPLY_ARRAY(cc, reply, 2);
+    CHECK_REPLY_OK(cc, reply->element[0]);
+    CHECK_REPLY_INT(cc, reply->element[1], 100);
+    freeReplyObject(reply);
+}
+
+void test_pipeline_to_single_node(redisClusterContext *cc) {
+    int status;
+    redisReply *reply;
+
+    dictIterator di;
+    dictInitIterator(&di, cc->nodes);
+
+    dictEntry *de = dictNext(&di);
+    assert(de);
+    cluster_node *node = dictGetEntryVal(de);
+    assert(node);
+
+    status = redisClusterAppendCommandToNode(cc, node, "DBSIZE");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    // Trigger send of pipeline commands
+    redisClusterGetReply(cc, (void *)&reply);
+    CHECK_REPLY(cc, reply);
+    CHECK_REPLY_TYPE(reply, REDIS_REPLY_INTEGER);
+    freeReplyObject(reply);
+}
+
+void test_pipeline_to_all_nodes(redisClusterContext *cc) {
+
+    nodeIterator ni;
+    initNodeIterator(&ni, cc);
+
+    cluster_node *node;
+    while ((node = nodeNext(&ni)) != NULL) {
+        int status = redisClusterAppendCommandToNode(cc, node, "DBSIZE");
+        ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    }
+
+    // Get replies from 3 node cluster
+    redisReply *reply;
+    redisClusterGetReply(cc, (void *)&reply);
+    CHECK_REPLY(cc, reply);
+    CHECK_REPLY_TYPE(reply, REDIS_REPLY_INTEGER);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply);
+    CHECK_REPLY(cc, reply);
+    CHECK_REPLY_TYPE(reply, REDIS_REPLY_INTEGER);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply);
+    CHECK_REPLY(cc, reply);
+    CHECK_REPLY_TYPE(reply, REDIS_REPLY_INTEGER);
+    freeReplyObject(reply);
+
+    redisClusterGetReply(cc, (void *)&reply);
+    assert(reply == NULL);
+}
+
+void test_pipeline_transaction(redisClusterContext *cc) {
+    int status;
+    redisReply *reply;
+
+    cluster_node *node = redisClusterGetNodeByKey(cc, "foo");
+    assert(node);
+
+    status = redisClusterAppendCommandToNode(cc, node, "MULTI");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommandToNode(cc, node, "SET foo 199");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommandToNode(cc, node, "INCR foo");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    status = redisClusterAppendCommandToNode(cc, node, "EXEC");
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    // Trigger send of pipeline commands
+    {
+        redisClusterGetReply(cc, (void *)&reply); // MULTI
+        CHECK_REPLY_OK(cc, reply);
+        freeReplyObject(reply);
+
+        redisClusterGetReply(cc, (void *)&reply); // SET
+        CHECK_REPLY_QUEUED(cc, reply);
+        freeReplyObject(reply);
+
+        redisClusterGetReply(cc, (void *)&reply); // INCR
+        CHECK_REPLY_QUEUED(cc, reply);
+        freeReplyObject(reply);
+
+        redisClusterGetReply(cc, (void *)&reply); // EXEC
+        CHECK_REPLY_ARRAY(cc, reply, 2);
+        CHECK_REPLY_OK(cc, reply->element[0]);
+        CHECK_REPLY_INT(cc, reply->element[1], 200);
+        freeReplyObject(reply);
+    }
+}
+
+//------------------------------------------------------------------------------
+// Async API
+//------------------------------------------------------------------------------
+typedef struct ExpectedResult {
+    int type;
+    char *str;
+    bool disconnect;
+    bool noreply;
+    char *errstr;
+} ExpectedResult;
+
+// Callback for Redis connects and disconnects
+void callbackExpectOk(const redisAsyncContext *ac, int status) {
+    UNUSED(ac);
+    assert(status == REDIS_OK);
+}
+
+// Callback for async commands, verifies the redisReply
+void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
+    redisReply *reply = (redisReply *)r;
+    ExpectedResult *expect = (ExpectedResult *)privdata;
+    if (expect->noreply) {
+        assert(reply == NULL);
+        assert(strcmp(cc->errstr, expect->errstr) == 0);
+    } else {
+        assert(reply != NULL);
+        assert(reply->type == expect->type);
+        if (reply->type != REDIS_REPLY_INTEGER)
+            assert(strcmp(reply->str, expect->str) == 0);
+    }
+    if (expect->disconnect)
+        redisClusterAsyncDisconnect(cc);
+}
+
+void test_async_to_single_node() {
+    int status;
+
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+    redisClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    redisClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
+    redisClusterSetOptionMaxRedirect(acc->cc, 1);
+    redisClusterSetOptionRouteUseSlots(acc->cc);
+    status = redisClusterConnect2(acc->cc);
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    struct event_base *base = event_base_new();
+    status = redisClusterLibeventAttach(acc, base);
+    assert(status == REDIS_OK);
+
+    dictIterator di;
+    dictInitIterator(&di, acc->cc->nodes);
+
+    dictEntry *de = dictNext(&di);
+    assert(de);
+    cluster_node *node = dictGetEntryVal(de);
+    assert(node);
+
+    ExpectedResult r1 = {.type = REDIS_REPLY_INTEGER, .disconnect = true};
+    status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
+                                            "DBSIZE");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+}
+
+void test_async_to_all_nodes() {
+    int status;
+
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+    redisClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    redisClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
+    redisClusterSetOptionMaxRedirect(acc->cc, 1);
+    redisClusterSetOptionRouteUseSlots(acc->cc);
+    status = redisClusterConnect2(acc->cc);
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    struct event_base *base = event_base_new();
+    status = redisClusterLibeventAttach(acc, base);
+    assert(status == REDIS_OK);
+
+    nodeIterator ni;
+    initNodeIterator(&ni, acc->cc);
+
+    ExpectedResult r1 = {.type = REDIS_REPLY_INTEGER};
+
+    cluster_node *node;
+    while ((node = nodeNext(&ni)) != NULL) {
+
+        status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
+                                                "DBSIZE");
+        ASSERT_MSG(status == REDIS_OK, acc->errstr);
+    }
+
+    // Normal command to trigger disconnect
+    ExpectedResult r2 = {
+        .type = REDIS_REPLY_STATUS, .str = "OK", .disconnect = true};
+    status = redisClusterAsyncCommand(acc, commandCallback, &r2, "SET foo bar");
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+}
+
+int main() {
+    int status;
+
+    redisClusterContext *cc = redisClusterContextInit();
+    assert(cc);
+    redisClusterSetOptionAddNodes(cc, CLUSTER_NODE);
+    redisClusterSetOptionRouteUseSlots(cc);
+    redisClusterSetOptionMaxRedirect(cc, 1);
+    status = redisClusterConnect2(cc);
+    ASSERT_MSG(status == REDIS_OK, cc->errstr);
+
+    // Synchronous API
+    test_command_to_single_node(cc);
+    test_command_to_all_nodes(cc);
+    test_transaction(cc);
+
+    // Pipeline API
+    test_pipeline_to_single_node(cc);
+    test_pipeline_to_all_nodes(cc);
+    test_pipeline_transaction(cc);
+
+    redisClusterFree(cc);
+
+    // Asynchronous API
+    test_async_to_single_node();
+    test_async_to_all_nodes();
+
+    return 0;
+}

--- a/tests/scripts/dbsize-to-all-nodes-test.sh
+++ b/tests/scripts/dbsize-to-all-nodes-test.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient}
+testname=dbsize-to-all-nodes-test
+
+# Sync processes waiting for CONT signals.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid1=$!;
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid2=$!;
+
+# Start simulated redis node #1
+timeout 5s ./simulated-redis.pl -p 7403 -d --sigcont $syncpid1 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 8383, ["127.0.0.1", 7403, "nodeid7403"]], [8384, 16383, ["127.0.0.1", 7404, "nodeid7404"]]]
+EXPECT CLOSE
+EXPECT CONNECT
+EXPECT ["DBSIZE"]
+SEND 11
+EXPECT CLOSE
+EOF
+server1=$!
+
+# Start simulated redis node #2
+timeout 5s ./simulated-redis.pl -p 7404 -d --sigcont $syncpid2 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["DBSIZE"]
+SEND 88
+EXPECT CLOSE
+EOF
+server2=$!
+
+# Wait until both nodes are ready to accept client connections
+wait $syncpid1 $syncpid2;
+
+# Run client
+echo 'DBSIZE' | timeout 3s "$clientprog" 127.0.0.1:7403 > "$testname.out"
+clientexit=$?
+
+# Wait for servers to exit
+wait $server1; server1exit=$?
+wait $server2; server2exit=$?
+
+# Check exit statuses
+if [ $server1exit -ne 0 ]; then
+    echo "Simulated server #1 exited with status $server1exit"
+    exit $server1exit
+fi
+if [ $server2exit -ne 0 ]; then
+    echo "Simulated server #2 exited with status $server2exit"
+    exit $server2exit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from clusterclient
+echo '11\n88' | cmp "$testname.out" - || exit 99
+
+# Clean up
+rm "$testname.out"

--- a/tests/scripts/simulated-redis.pl
+++ b/tests/scripts/simulated-redis.pl
@@ -101,7 +101,7 @@ while (<>) {
     s/^\s+//; # trim leading whitespace
     s/\s+$//; # trim trailing whitespace
     next if /^$/; # skip empty lines
-    print "(port $port) $_" if $debug;
+    print "(port $port) $_\n" if $debug;
     if (/^SEND (.*)/) {
         my $data = $1;
         if ($data =~ /^[-+\$\*:]/) {

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -15,12 +15,18 @@
 #define CHECK_REPLY_TYPE(_reply, _type)                                        \
     { ASSERT_MSG((_reply->type == _type), "Reply type incorrect"); }
 
-#define CHECK_REPLY_OK(_ctx, _reply)                                           \
+#define CHECK_REPLY_STATUS(_ctx, _reply, _str)                                 \
     {                                                                          \
         CHECK_REPLY(_ctx, _reply);                                             \
         CHECK_REPLY_TYPE(_reply, REDIS_REPLY_STATUS);                          \
-        ASSERT_MSG((strcmp(_reply->str, "OK") == 0), _ctx->errstr);            \
+        ASSERT_MSG((strcmp(_reply->str, _str) == 0), _ctx->errstr);            \
     }
+
+#define CHECK_REPLY_OK(_ctx, _reply)                                           \
+    { CHECK_REPLY_STATUS(_ctx, _reply, "OK") }
+
+#define CHECK_REPLY_QUEUED(_ctx, _reply)                                       \
+    { CHECK_REPLY_STATUS(_ctx, _reply, "QUEUED") }
 
 #define CHECK_REPLY_INT(_ctx, _reply, _value)                                  \
     {                                                                          \


### PR DESCRIPTION
Introduce new APIs for sending blocked, transaction and async commands to a
given node. This avoids the parsing step done in the legacy API and enables
keyless commands to be sent aswell, like for transactions.
Redirects are not handled when using this API.
```
void *redisClusterCommandToNode(redisClusterContext *cc, cluster_node *node..
int redisClusterAppendCommandToNode(redisClusterContext *cc, cluster_node *node..
int redisClusterAsyncCommandToNode(redisClusterAsyncContext *acc, cluster_node *node..
```
To send commands to all nodes a node iterator is introduced. It is based on the dict iterator to traverse
the existing nodes dict, but with the additional handling of changes in the nodes dict.
When a route refresh is performed nodes might be added or removed, and since the dict is currently
replaced cluster_node pointers will be invalid.

A route refresh will trigger a single restart of the now invalid iterator to make sure all nodes receives the command.
```
void initNodeIterator(nodeIterator *iter, redisClusterContext *cc);
cluster_node *nodeNext(nodeIterator *iter);
```
Usage examples:
- see ct_usecases.c  (sync, pipeline and async variants)

#### Additional changes
To be able to create a nodeIterator on the stack the size of a dictIterator needs to be known, which requires the dict type to be non-static.