### PR TITLE
Correct error messages during async connection problems

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -3666,8 +3666,13 @@ redisAsyncContext *actx_get_by_node(redisClusterAsyncContext *acc,
 
     ac = redisAsyncConnect(node->host, node->port);
     if (ac == NULL) {
-        __redisClusterAsyncSetError(acc, REDIS_ERR_OTHER,
-                                    "node host or port is error");
+        __redisClusterAsyncSetError(acc, REDIS_ERR_OOM, "Out of memory");
+        return NULL;
+    }
+
+    if (ac->err) {
+        __redisClusterAsyncSetError(acc, ac->err, ac->errstr);
+        redisAsyncFree(ac);
         return NULL;
     }
 
@@ -3695,7 +3700,8 @@ redisAsyncContext *actx_get_by_node(redisClusterAsyncContext *acc,
     if (acc->adapter) {
         ret = acc->attach_fn(ac, acc->adapter);
         if (ret != REDIS_OK) {
-            __redisClusterAsyncSetError(acc, ac->c.err, ac->c.errstr);
+            __redisClusterAsyncSetError(acc, REDIS_ERR_OTHER,
+                                        "Failed to attach event adapter");
             redisAsyncFree(ac);
             return NULL;
         }
@@ -3750,8 +3756,7 @@ actx_get_after_update_route_by_slot(redisClusterAsyncContext *acc,
 
     ac = actx_get_by_node(acc, node);
     if (ac == NULL) {
-        __redisClusterAsyncSetError(acc, REDIS_ERR_OTHER,
-                                    "actx get by node error");
+        /* Specific error already set */
         return NULL;
     } else if (ac->err) {
         __redisClusterAsyncSetError(acc, ac->err, ac->errstr);
@@ -3956,8 +3961,7 @@ static void redisClusterAsyncCallback(redisAsyncContext *ac, void *r,
 
             ac_retry = actx_get_by_node(acc, node);
             if (ac_retry == NULL) {
-                __redisClusterAsyncSetError(acc, REDIS_ERR_OTHER,
-                                            "actx get by node error");
+                /* Specific error already set */
                 goto done;
             } else if (ac_retry->err) {
                 __redisClusterAsyncSetError(acc, ac_retry->err,
@@ -4101,8 +4105,7 @@ int redisClusterAsyncFormattedCommand(redisClusterAsyncContext *acc,
 
     ac = actx_get_by_node(acc, node);
     if (ac == NULL) {
-        __redisClusterAsyncSetError(acc, REDIS_ERR_OTHER,
-                                    "actx get by node error");
+        /* Specific error already set */
         goto error;
     } else if (ac->err) {
         __redisClusterAsyncSetError(acc, ac->err, ac->errstr);


### PR DESCRIPTION
This change will give better error messages during connection problems in the async API.
Detailed error message set in `actx_get_by_node()` will no longer be replaced by a high-level generic message.

Start using `redisClusterReset()` in the OOM testcase to make sure each test has a fresh start without pre-allocated queues and lists.