### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 0.Y.Z - Y D, 2021
+### 0.6.0 - Feb 09, 2021
 * Minimum required version of CMake changed to 3.11 (from 3.14)
 * Re-added the Makefile for symmetry with hiredis, which also enables
   support for statically-linked libraries.

--- a/COPYING
+++ b/COPYING
@@ -1,8 +1,8 @@
 Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
 Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
 Copyright (c) 2020, Nick <heronr1 at gmail dot com>
-Copyright (c) 2020, Bjorn Svensson <bjorn.a.svensson at est dot tech>
-Copyright (c) 2020, Viktor Söderqvist <viktor.soderqvist at est dot tech>
+Copyright (c) 2020-2021, Bjorn Svensson <bjorn.a.svensson at est dot tech>
+Copyright (c) 2020-2021, Viktor Söderqvist <viktor.soderqvist at est dot tech>
 
 All rights reserved.
 

--- a/command.c
+++ b/command.c
@@ -1,7 +1,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <hiredis/alloc.h>
-#include <string.h>
+#include <strings.h>
 
 #include "command.h"
 #include "hiarray.h"


### PR DESCRIPTION
### 0.6.0 - Feb 09, 2021
* Minimum required version of CMake changed to 3.11 (from 3.14)
* Re-added the Makefile for symmetry with hiredis, which also enables
  support for statically-linked libraries.
* Improved examples
* Corrected crashes and leaks in OOM scenarios
* New API for sending commands to specific node
* New API for node iteration, can be used for sending commands
  to some or all nodes.