### PR TITLE
Add support for stream commands

### DIFF
--- a/command.h
+++ b/command.h
@@ -95,8 +95,18 @@ typedef enum cmd_parse_result {
     ACTION(REQ_REDIS_SUNION)                                                   \
     ACTION(REQ_REDIS_SUNIONSTORE)                                              \
     ACTION(REQ_REDIS_SSCAN)                                                    \
+    ACTION(REQ_REDIS_XACK)                                                     \
+    ACTION(REQ_REDIS_XADD)                                                     \
+    ACTION(REQ_REDIS_XAUTOCLAIM)                                               \
+    ACTION(REQ_REDIS_XCLAIM)                                                   \
+    ACTION(REQ_REDIS_XDEL)                                                     \
     ACTION(REQ_REDIS_XGROUP)                                                   \
     ACTION(REQ_REDIS_XINFO)                                                    \
+    ACTION(REQ_REDIS_XLEN)                                                     \
+    ACTION(REQ_REDIS_XPENDING)                                                 \
+    ACTION(REQ_REDIS_XRANGE)                                                   \
+    ACTION(REQ_REDIS_XREVRANGE)                                                \
+    ACTION(REQ_REDIS_XTRIM)                                                    \
     ACTION(REQ_REDIS_ZADD) /* redis requests - sorted sets */                  \
     ACTION(REQ_REDIS_ZCARD)                                                    \
     ACTION(REQ_REDIS_ZCOUNT)                                                   \

--- a/command.h
+++ b/command.h
@@ -95,6 +95,8 @@ typedef enum cmd_parse_result {
     ACTION(REQ_REDIS_SUNION)                                                   \
     ACTION(REQ_REDIS_SUNIONSTORE)                                              \
     ACTION(REQ_REDIS_SSCAN)                                                    \
+    ACTION(REQ_REDIS_XGROUP)                                                   \
+    ACTION(REQ_REDIS_XINFO)                                                    \
     ACTION(REQ_REDIS_ZADD) /* redis requests - sorted sets */                  \
     ACTION(REQ_REDIS_ZCARD)                                                    \
     ACTION(REQ_REDIS_ZCOUNT)                                                   \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
 endif()
 
 find_program(Docker_EXECUTABLE docker)
-set(CONTAINER "bjosv/redis-cluster:latest") # When supporting password and IPv6, change to: grokzen/redis-cluster:vX.X
+set(CONTAINER "bjosv/redis-cluster:6.2.0") # When supporting password change to: grokzen/redis-cluster:X.X.X
 
 add_custom_target(start
   COMMAND ${Docker_EXECUTABLE} run --name docker-cluster -d -p 7000-7006:7000-7006 ${CONTAINER} || (exit 0)


### PR DESCRIPTION
This adds tests and support for all stream commands.

The following commands are now handled by the regular API (like `redisClusterCommand()`) and are sent to the cluster node that handles the stream:
`XACK`, `XADD`, `XAUTOCLAIM`, `XCLAIM`, `XDEL`, `XGROUP`, `XINFO`, `XLEN`, `XPENDING`, `XRANGE`, `XREVRANGE` and `XTRIM`

The stream commands `XREAD` and `XREADGROUP` currently requires to be sent using the specific node API,
like `redisClusterCommandToNode()`, this due to that the position of the stream key is not in a fixed position.
