### PR TITLE
fix dbsize-to-all-nodes-test test

### DIFF
--- a/tests/scripts/dbsize-to-all-nodes-test.sh
+++ b/tests/scripts/dbsize-to-all-nodes-test.sh
@@ -59,7 +59,7 @@ if [ $clientexit -ne 0 ]; then
 fi
 
 # Check the output from clusterclient
-echo '11\n88' | cmp "$testname.out" - || exit 99
+printf '11\n88\n' | cmp "$testname.out" - || exit 99
 
 # Clean up
 rm "$testname.out"


### PR DESCRIPTION
This test didn't work on my system because `echo` didn't replace `\n` with a newline. Using `printf` works (see https://github.com/koalaman/shellcheck/wiki/SC2028).