### PR TITLE
Build fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
 BreakBeforeTernaryOperators: false
+ReflowComments: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,6 @@
 name: CI
 
-on:
-  push:
-  pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-      - '**:**'
+on: [push, pull_request]
 
 jobs:
   checkers:


### PR DESCRIPTION
* Trigger CI builds on all push and pull requests
  The trick to make sure that only one build was triggered did not work in all scenarios.

* Disable ReflowComments in clang-format
  clang-format will attempt to re-flow the comments which breaks the copyright comments in many places.
  Disabling ReflowComments will make sure clang-format is not reshuffling longer comment lines, like copyright text, ascii-art and more.  
