### PR TITLE
fix sizeof argument in call to calloc for reply->element vector

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -2892,7 +2892,7 @@ static void *command_post_fragment(redisClusterContext *cc, struct cmd *command,
         key_count = hiarray_n(command->keys);
 
         reply->elements = key_count;
-        reply->element = hi_calloc(key_count, sizeof(*reply));
+        reply->element = hi_calloc(key_count, sizeof(*reply->element));
         if (reply->element == NULL) {
             goto oom;
         }


### PR DESCRIPTION
reply->element is a vector of redisReply pointers

Previously, the size of the redisReply datastructure got allocated for each element of the vector. With this commit only the size of a pointer to a redisReply does get allocated.

In the lines below only the pointer addresses of e.g. `reply->element[i]` are updated, but no data is copied, so I'm 99% confident that this is a correct change. fwiw, all tests still pass.