### PR TITLE
Include <sys/socket.h> for builds on the BSD platforms

### DIFF
--- a/hiutil.c
+++ b/hiutil.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/types.h>
 
 #ifndef WIN32


### PR DESCRIPTION
Networking functions, types and macros like setsockopt,
send, recv, struct linger, SOL_SOCKET and so on do not
build on the BSD platforms if the socket header is not
included (as per man pages like send(2), setsockopt(2),
etc).  Fixed by adding it to hiutil.c which appears to
be the only location we need it.