### PR TITLE
Build the build examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,11 @@ jobs:
       working-directory: build
       shell: bash
       run: make stop
+    - name: Build examples
+      shell: bash
+      env:
+        CC: ${{ matrix.compiler }}
+      run: |
+        examples/using_cmake_externalproject/build.sh
+        examples/using_cmake_separate/build.sh
+        examples/using_make/build.sh

--- a/examples/src/CMakeLists.txt
+++ b/examples/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.11)
 project(examples LANGUAGES C)
 
 # Handle libevent and hiredis

--- a/examples/using_cmake_externalproject/CMakeLists.txt
+++ b/examples/using_cmake_externalproject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.11)
 project(hiredis_cluster_externalproject)
 include(ExternalProject)
 
@@ -6,7 +6,8 @@ ExternalProject_Add(hiredis
   PREFIX hiredis
   GIT_REPOSITORY  https://github.com/redis/hiredis
   GIT_TAG         v1.0.0
-  CMAKE_CACHE_ARGS
+  CMAKE_ARGS
+    "-DCMAKE_C_FLAGS:STRING=-std=c99"
     "-DENABLE_SSL:BOOL=ON"
     "-DCMAKE_BUILD_TYPE:STRING=Debug"
     "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis"
@@ -15,7 +16,7 @@ ExternalProject_Add(hiredis
 ExternalProject_Add(hiredis_cluster
   PREFIX hiredis_cluster
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../.."
-  CMAKE_CACHE_ARGS
+  CMAKE_ARGS
     "-DENABLE_SSL:BOOL=ON"
     "-DDISABLE_TESTS:BOOL=ON"
     "-DDOWNLOAD_HIREDIS:BOOL=OFF"
@@ -30,7 +31,7 @@ ExternalProject_Add(examples
   PREFIX examples
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../src"
   INSTALL_COMMAND ""
-  CMAKE_CACHE_ARGS
+  CMAKE_ARGS
     "-DCMAKE_BUILD_TYPE:STRING=Debug"
     "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/examples"
     "-Dhiredis_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/hiredis/share/hiredis"

--- a/examples/using_cmake_externalproject/build.sh
+++ b/examples/using_cmake_externalproject/build.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 set -e
+
+# This script builds and installs hiredis and hiredis-cluster using
+# CMakes ExternalProject module.
+# The shared library variants are used when building the examples.
+
 script_dir=$(realpath "${0%/*}")
 
-# Create build directory
+# Prepare a build directory
 mkdir -p ${script_dir}/build
+cd ${script_dir}/build
 
 # Generate makefiles
-cmake -B ${script_dir}/build -S ${script_dir}
+cmake ..
 
 # Build
-VERBOSE=1 make -C ${script_dir}/build
+VERBOSE=1 make

--- a/examples/using_cmake_separate/build.sh
+++ b/examples/using_cmake_separate/build.sh
@@ -1,42 +1,46 @@
 #!/bin/sh
 set -e
+
+# This script builds and installs hiredis and hiredis-cluster as separate
+# steps using CMake.
+# The shared library variants are used when building the examples.
+
 script_dir=$(realpath "${0%/*}")
+repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
 hiredis_version=1.0.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
-# Build and install hiredis using CMake
+# Build and install downloaded hiredis using CMake
 mkdir -p ${script_dir}/hiredis_build
+cd ${script_dir}/hiredis_build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_TESTS=ON -DENABLE_SSL=ON \
       -DCMAKE_C_FLAGS="-std=c99" \
-      -S ${script_dir}/hiredis-${hiredis_version} -B ${script_dir}/hiredis_build
-make -C ${script_dir}/hiredis_build DESTDIR=${script_dir}/install install
+      ${script_dir}/hiredis-${hiredis_version}
+make DESTDIR=${script_dir}/install install
 
 
-# Download hiredis-cluster
-hiredis_cluster_version=0.5.0
-curl -L https://github.com/Nordix/hiredis-cluster/archive/${hiredis_cluster_version}.tar.gz | tar -xz -C ${script_dir}
-
-# Build and install hiredis-cluster using CMake
+# Build and install hiredis-cluster from the repo using CMake
 # Uses '-Dxxxx_DIR' defines that points to hiredis-config.cmake and hiredis_ssl-config.cmake installed
-# above. These files describes the dependecy packages.
+# above. These files defines paths and variables needed by CMake.
 mkdir -p ${script_dir}/hiredis_cluster_build
+cd ${script_dir}/hiredis_cluster_build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_TESTS=ON -DENABLE_SSL=ON -DDOWNLOAD_HIREDIS=OFF \
       -DCMAKE_C_FLAGS="-std=c99 -D_XOPEN_SOURCE=600" \
       -Dhiredis_DIR=${script_dir}/install/usr/local/share/hiredis \
       -Dhiredis_ssl_DIR=${script_dir}/install/usr/local/share/hiredis_ssl \
-      -S ${script_dir}/hiredis-cluster-${hiredis_cluster_version} -B ${script_dir}/hiredis_cluster_build
-make -C ${script_dir}/hiredis_cluster_build DESTDIR=${script_dir}/install install
+      ${repo_dir}
+make DESTDIR=${script_dir}/install clean install
 
 
-# Build examples from this repo. but link with above built libraries
-# installed in ${script_dir}/install/
+# Build examples using headers and libraries installed in previous steps.
 mkdir -p ${script_dir}/example_build
+cd ${script_dir}/example_build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_C_FLAGS="-std=c99" \
       -Dhiredis_DIR=${script_dir}/install/usr/local/share/hiredis \
       -Dhiredis_ssl_DIR=${script_dir}/install/usr/local/share/hiredis_ssl \
       -Dhiredis_cluster_DIR=${script_dir}/install/usr/local/share/hiredis_cluster \
-      -S ${script_dir}/../src -B ${script_dir}/example_build
-make -C ${script_dir}/example_build
+      ${script_dir}/../src
+make


### PR DESCRIPTION
Verifies that the different build and install alternatives works.

Lowering the minimum CMake requirement for the examples to match the
library (v3.11) and change some parts due to its lack of functionality.