### PR TITLE
Add libev adapter and tests for event libraries libev and libuv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
     - name: Prepare
-      run: sudo apt install libevent-dev ${{ matrix.compiler }}
+      run: sudo apt install libevent-dev libuv1-dev ${{ matrix.compiler }}
     - name: Setup cmake
       # Temporary disabled due to actions-setup-cmake/issues/21
       # uses: jwlawson/actions-setup-cmake@v1.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
     - name: Prepare
-      run: sudo apt install libevent-dev libuv1-dev ${{ matrix.compiler }}
+      run: sudo apt install libevent-dev libuv1-dev libev-dev ${{ matrix.compiler }}
     - name: Setup cmake
       # Temporary disabled due to actions-setup-cmake/issues/21
       # uses: jwlawson/actions-setup-cmake@v1.6

--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ redisClusterReset(clusterContext);
 ## Cluster asynchronous API
 
 Hiredis-cluster comes with an asynchronous cluster API that works with many event systems.
-Currently there are adapters that enables support for libevent and Redis Event Library (ae),
-but more can be added. The hiredis library has adapters for additional event systems that
-easily can be adapted for hiredis-cluster as well.
+Currently there are adapters that enables support for `libevent`, `libev`, `libuv` and
+Redis Event Library (`ae`), but more can be added. The hiredis library has adapters for
+additional event systems that easily can be adapted for hiredis-cluster as well.
 
 ### Connecting
 
@@ -346,7 +346,7 @@ callbacks have been executed. After this, the disconnection callback is executed
 ### Using event library *X*
 
 There are a few hooks that need to be set on the cluster context object after it is created.
-See the `adapters/` directory for bindings to *ae* and *libevent*.
+See the `adapters/` directory for bindings to *libevent* and a range of other event libraries.
 
 ### Allocator injection
 

--- a/adapters/libev.h
+++ b/adapters/libev.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Björn Svensson <bjorn.a.svensson@est.tech>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __HIREDIS_CLUSTER_LIBEV_H__
+#define __HIREDIS_CLUSTER_LIBEV_H__
+
+#include "../hircluster.h"
+#include <hiredis/adapters/libev.h>
+
+static int redisLibevAttach_link(redisAsyncContext *ac, void *loop) {
+    return redisLibevAttach((struct ev_loop *)loop, ac);
+}
+
+static int redisClusterLibevAttach(redisClusterAsyncContext *acc,
+                                   struct ev_loop *loop) {
+    if (loop == NULL || acc == NULL) {
+        return REDIS_ERR;
+    }
+
+    acc->adapter = loop;
+    acc->attach_fn = redisLibevAttach_link;
+
+    return REDIS_OK;
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,8 @@ add_custom_target(stop
 )
 
 # Find dependencies
-find_library(EVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
+find_library(LIBEVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
+find_library(LIBUV_LIBRARY uv HINTS /usr/lib/x86_64-linux-gnu)
 
 if(MSVC)
   # MS Visual: Suppress warnings
@@ -52,7 +53,7 @@ set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
 list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 
 add_executable(ct_async ct_async.c)
-target_link_libraries(ct_async hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_async hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_async COMMAND "$<TARGET_FILE:ct_async>")
 set_tests_properties(ct_async PROPERTIES LABELS "CT")
 
@@ -62,29 +63,29 @@ add_test(NAME ct_commands COMMAND "$<TARGET_FILE:ct_commands>")
 set_tests_properties(ct_commands PROPERTIES LABELS "CT")
 
 add_executable(ct_connection ct_connection.c)
-target_link_libraries(ct_connection hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_connection hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_connection COMMAND "$<TARGET_FILE:ct_connection>")
 set_tests_properties(ct_connection PROPERTIES LABELS "CT")
 
 add_executable(ct_pipeline ct_pipeline.c)
-target_link_libraries(ct_pipeline hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_pipeline hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_pipeline COMMAND "$<TARGET_FILE:ct_pipeline>")
 set_tests_properties(ct_pipeline PROPERTIES LABELS "CT")
 
 add_executable(ct_connection_ipv6 ct_connection_ipv6.c)
-target_link_libraries(ct_connection_ipv6 hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_connection_ipv6 hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 if(ENABLE_IPV6_TESTS)
   add_test(NAME ct_connection_ipv6 COMMAND "$<TARGET_FILE:ct_connection_ipv6>")
   set_tests_properties(ct_connection_ipv6 PROPERTIES LABELS "CT")
 endif()
 
 add_executable(ct_out_of_memory_handling ct_out_of_memory_handling.c)
-target_link_libraries(ct_out_of_memory_handling hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_out_of_memory_handling hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_out_of_memory_handling COMMAND "$<TARGET_FILE:ct_out_of_memory_handling>")
 set_tests_properties(ct_out_of_memory_handling PROPERTIES LABELS "CT")
 
 add_executable(ct_specific_nodes ct_specific_nodes.c)
-target_link_libraries(ct_specific_nodes hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(ct_specific_nodes hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_specific_nodes COMMAND "$<TARGET_FILE:ct_specific_nodes>")
 set_tests_properties(ct_specific_nodes PROPERTIES LABELS "CT")
 
@@ -96,8 +97,15 @@ if(ENABLE_SSL)
 
   # Executable: async tls
   add_executable(example_async_tls main_async_tls.c)
-  target_link_libraries(example_async_tls hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+  target_link_libraries(example_async_tls hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
   add_dependencies(example_async_tls generate_tls_configs)
+endif()
+
+if(LIBUV_LIBRARY)
+  add_executable(ct_async_libuv ct_async_libuv.c)
+  target_link_libraries(ct_async_libuv hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBUV_LIBRARY})
+  add_test(NAME ct_async_libuv COMMAND "$<TARGET_FILE:ct_async_libuv>")
+  set_tests_properties(ct_async_libuv PROPERTIES LABELS "CT")
 endif()
 
 # Tests using simulated redis node
@@ -106,7 +114,7 @@ target_link_libraries(clusterclient hiredis_cluster hiredis ${SSL_LIBRARY})
 add_executable(clusterclient_all_nodes clusterclient_all_nodes.c)
 target_link_libraries(clusterclient_all_nodes hiredis_cluster hiredis ${SSL_LIBRARY})
 add_executable(clusterclient_async clusterclient_async.c)
-target_link_libraries(clusterclient_async hiredis_cluster hiredis ${SSL_LIBRARY} ${EVENT_LIBRARY})
+target_link_libraries(clusterclient_async hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME set-get-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/set-get-test.sh"
                  "$<TARGET_FILE:clusterclient>"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_custom_target(stop
 # Find dependencies
 find_library(LIBEVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
 find_library(LIBUV_LIBRARY uv HINTS /usr/lib/x86_64-linux-gnu)
+find_library(LIBEV_LIBRARY ev HINTS /usr/lib/x86_64-linux-gnu)
 
 if(MSVC)
   # MS Visual: Suppress warnings
@@ -106,6 +107,15 @@ if(LIBUV_LIBRARY)
   target_link_libraries(ct_async_libuv hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBUV_LIBRARY})
   add_test(NAME ct_async_libuv COMMAND "$<TARGET_FILE:ct_async_libuv>")
   set_tests_properties(ct_async_libuv PROPERTIES LABELS "CT")
+endif()
+
+if(LIBEV_LIBRARY)
+  add_executable(ct_async_libev ct_async_libev.c)
+  # Temporary remove warning of unused parameter due to an issue in hiredis libev adapter
+  target_compile_options(ct_async_libev PRIVATE -Wno-unused-parameter)
+  target_link_libraries(ct_async_libev hiredis_cluster hiredis ${SSL_LIBRARY} ${LIBEV_LIBRARY})
+  add_test(NAME ct_async_libev COMMAND "$<TARGET_FILE:ct_async_libev>")
+  set_tests_properties(ct_async_libev PROPERTIES LABELS "CT")
 endif()
 
 # Tests using simulated redis node

--- a/tests/ct_async_libev.c
+++ b/tests/ct_async_libev.c
@@ -1,0 +1,61 @@
+#include "adapters/libev.h"
+#include "hircluster.h"
+#include "test_utils.h"
+#include <assert.h>
+
+#define CLUSTER_NODE "127.0.0.1:7000"
+
+void setCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
+    UNUSED(privdata);
+    redisReply *reply = (redisReply *)r;
+    ASSERT_MSG(reply != NULL, acc->errstr);
+}
+
+void getCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
+    UNUSED(privdata);
+    redisReply *reply = (redisReply *)r;
+    ASSERT_MSG(reply != NULL, acc->errstr);
+
+    /* Disconnect after receiving the first reply to GET */
+    redisClusterAsyncDisconnect(acc);
+}
+
+void connectCallback(const redisAsyncContext *ac, int status) {
+    ASSERT_MSG(status == REDIS_OK, ac->errstr);
+    printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
+}
+
+void disconnectCallback(const redisAsyncContext *ac, int status) {
+    ASSERT_MSG(status == REDIS_OK, ac->errstr);
+    printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
+}
+
+int main(int argc, char **argv) {
+    UNUSED(argc);
+    UNUSED(argv);
+
+    redisClusterAsyncContext *acc =
+        redisClusterAsyncConnect(CLUSTER_NODE, HIRCLUSTER_FLAG_NULL);
+    assert(acc);
+    ASSERT_MSG(acc->err == 0, acc->errstr);
+
+    int status;
+    status = redisClusterLibevAttach(acc, EV_DEFAULT);
+    assert(status == REDIS_OK);
+
+    redisClusterAsyncSetConnectCallback(acc, connectCallback);
+    redisClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
+
+    status = redisClusterAsyncCommand(acc, setCallback, (char *)"ID",
+                                      "SET key value");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    status =
+        redisClusterAsyncCommand(acc, getCallback, (char *)"ID", "GET key");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    ev_loop(EV_DEFAULT_ 0);
+
+    redisClusterAsyncFree(acc);
+    return 0;
+}

--- a/tests/ct_async_libuv.c
+++ b/tests/ct_async_libuv.c
@@ -1,0 +1,63 @@
+#include "adapters/libuv.h"
+#include "hircluster.h"
+#include "test_utils.h"
+#include <assert.h>
+
+#define CLUSTER_NODE "127.0.0.1:7000"
+
+void setCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
+    UNUSED(privdata);
+    redisReply *reply = (redisReply *)r;
+    ASSERT_MSG(reply != NULL, acc->errstr);
+}
+
+void getCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
+    UNUSED(privdata);
+    redisReply *reply = (redisReply *)r;
+    ASSERT_MSG(reply != NULL, acc->errstr);
+
+    /* Disconnect after receiving the first reply to GET */
+    redisClusterAsyncDisconnect(acc);
+}
+
+void connectCallback(const redisAsyncContext *ac, int status) {
+    ASSERT_MSG(status == REDIS_OK, ac->errstr);
+    printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
+}
+
+void disconnectCallback(const redisAsyncContext *ac, int status) {
+    ASSERT_MSG(status == REDIS_OK, ac->errstr);
+    printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
+}
+
+int main(int argc, char **argv) {
+    UNUSED(argc);
+    UNUSED(argv);
+
+    redisClusterAsyncContext *acc =
+        redisClusterAsyncConnect(CLUSTER_NODE, HIRCLUSTER_FLAG_NULL);
+    assert(acc);
+    ASSERT_MSG(acc->err == 0, acc->errstr);
+
+    int status;
+    uv_loop_t *loop = uv_default_loop();
+    status = redisClusterLibuvAttach(acc, loop);
+    assert(status == REDIS_OK);
+
+    redisClusterAsyncSetConnectCallback(acc, connectCallback);
+    redisClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
+
+    status = redisClusterAsyncCommand(acc, setCallback, (char *)"ID",
+                                      "SET key value");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    status =
+        redisClusterAsyncCommand(acc, getCallback, (char *)"ID", "GET key");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    uv_run(loop, UV_RUN_DEFAULT);
+
+    redisClusterAsyncFree(acc);
+    uv_loop_delete(loop);
+    return 0;
+}


### PR DESCRIPTION
Add adapter and test for using the event library `libev` for the asynchronous API
- Closes #48
- Found an issue in hiredis adapter impl. regarding unused parameters which will be addressed, but temporary fixed in the test binary.

Added a similar test for already handled `libuv`