### PR TITLE
Improve redisClusterReset documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ the `err` field in the context can be used to find out what the cause of this er
 void redisClusterReset(redisClusterContext *cc);
 ```
 Warning: You must call `redisClusterReset` function after one pipelining anyway.
+Warning: Calling `redisClusterReset` without pipelining first will reset all Redis connections.
 
 The following examples shows a simple cluster pipeline:
 ```c

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ the `err` field in the context can be used to find out what the cause of this er
 void redisClusterReset(redisClusterContext *cc);
 ```
 Warning: You must call `redisClusterReset` function after one pipelining anyway.
+
 Warning: Calling `redisClusterReset` without pipelining first will reset all Redis connections.
 
 The following examples shows a simple cluster pipeline:

--- a/hircluster.c
+++ b/hircluster.c
@@ -3637,7 +3637,6 @@ error:
     return REDIS_ERR;
 }
 
-
 /**
  * Resets cluster state after pipeline. 
  * Resets Redis node connections if pipeline commands were not called beforehand.

--- a/hircluster.c
+++ b/hircluster.c
@@ -3637,6 +3637,11 @@ error:
     return REDIS_ERR;
 }
 
+
+/**
+ * Resets cluster state after pipeline. 
+ * Resets Redis node connections if pipeline commands were not called beforehand.
+ */
 void redisClusterReset(redisClusterContext *cc) {
     int status;
     void *reply;


### PR DESCRIPTION
Hi,

In our use case we have a stateful Luajit wrapper for this driver, requiring us to reset the wrapper status each time (to avoid being stuck in pipeline mode without resetting the driver status between requests).
When we called that function, we also called redisResetCluster() - which causes a complete connection reset if not used after a pipeline.
Added a suggested PR to documentation to avoid future confusion in usage.

Thanks