### PR TITLE
ci: resolve final lgtm.com recommendations

### DIFF
--- a/hiutil.c
+++ b/hiutil.c
@@ -262,9 +262,6 @@ int _uint_len(uint32_t num) {
 }
 
 void hi_stacktrace(int skip_count) {
-    if (skip_count > 0) {
-    }
-
 #ifdef HI_HAVE_BACKTRACE
     void *stack[64];
     char **symbols;
@@ -283,18 +280,20 @@ void hi_stacktrace(int skip_count) {
     }
 
     hi_free(symbols);
+#else
+    (void)skip_count;
 #endif
 }
 
 void hi_stacktrace_fd(int fd) {
-    if (fd > 0) {
-    }
 #ifdef HI_HAVE_BACKTRACE
     void *stack[64];
     int size;
 
     size = backtrace(stack, 64);
     backtrace_symbols_fd(stack, size, fd);
+#else
+    (void)fd;
 #endif
 }
 


### PR DESCRIPTION
Remove conditional code with empty body that was being
used to avoid an unused-parameter compiler warning for
the case where HI_HAVE_BACKTRACE is not set.

The (void) pattern used here is a common alternative -
it avoids the warning, makes for slightly cleaner code
and removes the empty blocks that lgtm is recommending
against.