### PR TITLE
Add windows and macOS builds to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,11 @@ jobs:
     name: Run static checkers
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run clang-format style check (.c and .h)
       uses: jidicula/clang-format-action@v3.0.0
 
-  build:
+  ubuntu:
     name: ${{ matrix.cmake-build-type }}-build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }} sanitizer="${{ matrix.sanitizer }}"]
     runs-on: ubuntu-18.04
     strategy:
@@ -68,7 +68,7 @@ jobs:
         sudo sh /tmp/cmake.sh --prefix=/usr/local/ --exclude-subdir
         # Make sure we use correct version
         cmake --version | grep -c ${{ matrix.cmake-version }}.0
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Create build folder
       run: cmake -E make_directory build
     - name: Generate makefiles
@@ -105,3 +105,33 @@ jobs:
         examples/using_cmake_externalproject/build.sh
         examples/using_cmake_separate/build.sh
         examples/using_make/build.sh
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - name: Prepare
+        run: |
+          brew install cmake ninja openssl
+      - uses: actions/checkout@v3
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_SSL=ON
+          ninja -v
+
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Prepare
+        run: |
+          choco install -y ninja
+          vcpkg install --triplet x64-windows libevent
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+          ninja -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,7 @@ add_library(hiredis_cluster
   SHARED
   ${hiredis_cluster_sources})
 
-if(MSVC)
-  # MS Visual: Suppress warnings
-  target_compile_options(hiredis_cluster PRIVATE "/wd 4267" "/wd 4244")
-else()
+if(NOT MSVC)
   target_compile_options(hiredis_cluster PRIVATE -Wall -Wextra -pedantic -Werror)
 
   # Add extra defines when CMAKE_BUILD_TYPE is set to Debug
@@ -129,7 +126,15 @@ target_include_directories(hiredis_cluster PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 if(WIN32 OR MINGW)
-    TARGET_LINK_LIBRARIES(hiredis_cluster PRIVATE ws2_32 hiredis::hiredis)
+  target_link_libraries(hiredis_cluster ws2_32 hiredis)
+endif()
+
+if(APPLE)
+  if(ENABLE_SSL)
+    target_link_libraries(hiredis_cluster hiredis hiredis_ssl)
+  else()
+    target_link_libraries(hiredis_cluster hiredis)
+  endif()
 endif()
 
 if(NOT DISABLE_TESTS)

--- a/command.c
+++ b/command.c
@@ -31,7 +31,11 @@
 #include <ctype.h>
 #include <errno.h>
 #include <hiredis/alloc.h>
+#ifndef _WIN32
 #include <strings.h>
+#endif
+
+#include "win32.h"
 
 #include "command.h"
 #include "hiarray.h"

--- a/command.c
+++ b/command.c
@@ -35,11 +35,13 @@
 #include <strings.h>
 #endif
 
-#include "win32.h"
-
 #include "command.h"
 #include "hiarray.h"
 #include "hiutil.h"
+#include "win32.h"
+
+#define LF (uint8_t)10
+#define CR (uint8_t)13
 
 static uint64_t cmd_id = 0; /* command id counter */
 

--- a/hircluster.c
+++ b/hircluster.c
@@ -38,14 +38,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "win32.h"
-
 #include "adlist.h"
 #include "command.h"
 #include "dict.h"
 #include "hiarray.h"
 #include "hircluster.h"
 #include "hiutil.h"
+#include "win32.h"
 
 // Cluster errors are offset by 100 to be sufficiently out of range of
 // standard Redis errors
@@ -74,6 +73,9 @@
 #define CLUSTER_ADDRESS_SEPARATOR ","
 
 #define CLUSTER_DEFAULT_MAX_RETRY_COUNT 5
+
+#define CRLF "\x0d\x0a"
+#define CRLF_LEN (sizeof("\x0d\x0a") - 1)
 
 typedef struct cluster_async_data {
     redisClusterAsyncContext *acc;

--- a/hircluster.c
+++ b/hircluster.c
@@ -38,13 +38,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "win32.h"
+
 #include "adlist.h"
 #include "command.h"
 #include "dict.h"
 #include "hiarray.h"
 #include "hircluster.h"
 #include "hiutil.h"
-#include "win32.h"
 
 // Cluster errors are offset by 100 to be sufficiently out of range of
 // standard Redis errors

--- a/hiredis_cluster.def
+++ b/hiredis_cluster.def
@@ -2,21 +2,30 @@
 	actx_get_by_node
 	cluster_update_route
 	ctx_get_by_node
+	dictInitIterator
+	dictNext
+	initNodeIterator
+	nodeNext
 	parse_cluster_nodes
 	parse_cluster_slots
 	redisClusterAppendCommand
 	redisClusterAppendCommandArgv
+	redisClusterAppendCommandToNode
 	redisClusterAppendFormattedCommand
+	redisClusterAsyncContextInit
 	redisClusterAsyncCommand
 	redisClusterAsyncCommandArgv
+	redisClusterAsyncCommandToNode
 	redisClusterAsyncConnect
 	redisClusterAsyncDisconnect
 	redisClusterAsyncFormattedCommand
+	redisClusterAsyncFormattedCommandToNode
 	redisClusterAsyncFree
 	redisClusterAsyncSetConnectCallback
 	redisClusterAsyncSetDisconnectCallback
 	redisClusterCommand
 	redisClusterCommandArgv
+	redisClusterCommandToNode
 	redisClusterConnect
 	redisClusterConnect2
 	redisClusterConnectNonBlock
@@ -24,10 +33,12 @@
 	redisClusterContextInit
 	redisClusterFormattedCommand
 	redisClusterFree
+	redisClusterGetNodeByKey
 	redisClusterGetReply
 	redisClusterReset
 	redisClusterSetMaxRedirect
 	redisClusterSetOptionAddNode
+	redisClusterSetOptionAddNodes
 	redisClusterSetOptionConnectBlock
 	redisClusterSetOptionConnectNonBlock
 	redisClusterSetOptionConnectTimeout
@@ -36,7 +47,8 @@
 	redisClusterSetOptionParseSlaves
 	redisClusterSetOptionRouteUseSlots
 	redisClusterSetOptionTimeout
+	redisClusterSetOptionUsername
+	redisClusterSetOptionPassword
 	redisClustervAppendCommand
 	redisClustervAsyncCommand
 	redisClustervCommand
-	test_cluster_update_route

--- a/hiutil.c
+++ b/hiutil.c
@@ -48,9 +48,8 @@
 #include <execinfo.h>
 #endif
 
-#include "win32.h"
-
 #include "hiutil.h"
+#include "win32.h"
 
 #ifndef WIN32
 int hi_set_blocking(int sd) {
@@ -439,25 +438,3 @@ int64_t hi_usec_now(void) {
  * Return the current time in milliseconds since Epoch
  */
 int64_t hi_msec_now(void) { return hi_usec_now() / 1000LL; }
-
-void print_string_with_length(char *s, size_t len) {
-    char *token;
-    for (token = s; token <= s + len; token++) {
-        printf("%c", *token);
-    }
-    printf("\n");
-}
-
-void print_string_with_length_fix_CRLF(char *s, size_t len) {
-    char *token;
-    for (token = s; token < s + len; token++) {
-        if (*token == CR) {
-            printf("\\r");
-        } else if (*token == LF) {
-            printf("\\n");
-        } else {
-            printf("%c", *token);
-        }
-    }
-    printf("\n");
-}

--- a/hiutil.c
+++ b/hiutil.c
@@ -35,12 +35,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
 #include <sys/types.h>
 
 #ifndef WIN32
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 #endif
 
@@ -48,8 +48,9 @@
 #include <execinfo.h>
 #endif
 
-#include "hiutil.h"
 #include "win32.h"
+
+#include "hiutil.h"
 
 #ifndef WIN32
 int hi_set_blocking(int sd) {
@@ -308,7 +309,7 @@ void hi_assert(const char *cond, const char *file, int line, int panic) {
     abort();
 }
 
-int _vscnprintf(char *buf, size_t size, const char *fmt, va_list args) {
+static int _vscnprintf(char *buf, size_t size, const char *fmt, va_list args) {
     int n;
 
     n = vsnprintf(buf, size, fmt, args);

--- a/hiutil.h
+++ b/hiutil.h
@@ -42,20 +42,6 @@
 
 typedef int rstatus_t; /* return type */
 
-#define LF (uint8_t)10
-#define CR (uint8_t)13
-#define CRLF "\x0d\x0a"
-#define CRLF_LEN (sizeof("\x0d\x0a") - 1)
-
-#define NELEMS(a) ((sizeof(a)) / sizeof((a)[0]))
-
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
-
-#define SQUARE(d) ((d) * (d))
-#define VAR(s, s2, n) (((n) < 2) ? 0.0 : ((s2)-SQUARE(s) / (n)) / ((n)-1))
-#define STDDEV(s, s2, n) (((n) < 2) ? 0.0 : sqrt(VAR((s), (s2), (n))))
-
 #define HI_INET4_ADDRSTRLEN (sizeof("255.255.255.255") - 1)
 #define HI_INET6_ADDRSTRLEN                                                    \
     (sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255") - 1)
@@ -190,9 +176,6 @@ void hi_stacktrace_fd(int fd);
 int _scnprintf(char *buf, size_t size, const char *fmt, ...);
 int64_t hi_usec_now(void);
 int64_t hi_msec_now(void);
-
-void print_string_with_length(char *s, size_t len);
-void print_string_with_length_fix_CRLF(char *s, size_t len);
 
 uint16_t crc16(const char *buf, int len);
 

--- a/hiutil.h
+++ b/hiutil.h
@@ -33,13 +33,8 @@
 #ifndef __HIUTIL_H_
 #define __HIUTIL_H_
 
-#include <stdarg.h>
 #include <stdint.h>
 #include <sys/types.h>
-#if defined(_MSC_VER)
-#include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
-#endif
 
 #define HI_OK 0
 #define HI_ERROR -1
@@ -193,7 +188,6 @@ void hi_stacktrace(int skip_count);
 void hi_stacktrace_fd(int fd);
 
 int _scnprintf(char *buf, size_t size, const char *fmt, ...);
-int _vscnprintf(char *buf, size_t size, const char *fmt, va_list args);
 int64_t hi_usec_now(void);
 int64_t hi_msec_now(void);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,21 +39,16 @@ add_custom_target(stop
 # Find dependencies
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(GLIB_LIBRARY IMPORTED_TARGET glib-2.0)
-find_library(LIBEVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
 find_library(LIBUV_LIBRARY uv HINTS /usr/lib/x86_64-linux-gnu)
 find_library(LIBEV_LIBRARY ev HINTS /usr/lib/x86_64-linux-gnu)
+find_library(LIBEVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
+find_path(LIBEVENT_INCLUDES event2/event.h)
+include_directories(${LIBEVENT_INCLUDES})
 
 if(MSVC)
-  find_path(LIBEVENT_INCLUDES event2/event.h)
   find_library(LIBEVENT_LIBRARY Libevent)
-  include_directories(${LIBEVENT_INCLUDES})
 else()
   add_compile_options(-Wall -Wextra -pedantic -Werror)
-endif()
-
-if(APPLE)
-  # Set include path manually due to issue in CMake on macOS
-  include_directories(/usr/local/include)
 endif()
 
 # Debug mode for tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,10 +44,16 @@ find_library(LIBUV_LIBRARY uv HINTS /usr/lib/x86_64-linux-gnu)
 find_library(LIBEV_LIBRARY ev HINTS /usr/lib/x86_64-linux-gnu)
 
 if(MSVC)
-  # MS Visual: Suppress warnings
-  add_compile_options("/wd 4267" "/wd 4244")
+  find_path(LIBEVENT_INCLUDES event2/event.h)
+  find_library(LIBEVENT_LIBRARY Libevent)
+  include_directories(${LIBEVENT_INCLUDES})
 else()
   add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
+if(APPLE)
+  # Set include path manually due to issue in CMake on macOS
+  include_directories(/usr/local/include)
 endif()
 
 # Debug mode for tests

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -4,6 +4,7 @@
  */
 
 #include "hircluster.h"
+#include "win32.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/clusterclient_all_nodes.c
+++ b/tests/clusterclient_all_nodes.c
@@ -5,6 +5,7 @@
  */
 
 #include "hircluster.h"
+#include "win32.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -1,5 +1,6 @@
 #include "hircluster.h"
 #include "test_utils.h"
+#include "win32.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/ct_connection_ipv6.c
+++ b/tests/ct_connection_ipv6.c
@@ -1,5 +1,6 @@
 #include "hircluster.h"
 #include "test_utils.h"
+#include "win32.h"
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -1,6 +1,7 @@
 #include "adapters/libevent.h"
 #include "hircluster.h"
 #include "test_utils.h"
+#include "win32.h"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/win32.h
+++ b/win32.h
@@ -38,48 +38,10 @@
 #define inline __inline
 #endif
 
-#ifndef strcasecmp
-#define strcasecmp _stricmp
-#endif
-
 #ifndef strncasecmp
 #define strncasecmp _strnicmp
 #endif
 
-#ifndef strtok_r
-#define strtok_r strtok_s
-#endif
-
-#ifndef va_copy
-#define va_copy(d, s) ((d) = (s))
-#endif
-
-#ifndef snprintf
-#define snprintf c99_snprintf
-
-__inline int c99_vsnprintf(char *str, size_t size, const char *format,
-                           va_list ap) {
-    int count = -1;
-
-    if (size != 0)
-        count = _vsnprintf_s(str, size, _TRUNCATE, format, ap);
-    if (count == -1)
-        count = _vscprintf(format, ap);
-
-    return count;
-}
-
-__inline int c99_snprintf(char *str, size_t size, const char *format, ...) {
-    int count;
-    va_list ap;
-
-    va_start(ap, format);
-    count = c99_vsnprintf(str, size, format, ap);
-    va_end(ap);
-
-    return count;
-}
-#endif
 #endif /* _MSC_VER */
 
 #ifdef _WIN32


### PR DESCRIPTION
Adding Windows and macOS builds to CI to verify that hiredis-cluster supports the same platforms as hiredis.

Building on Windows required corrections in the exported functions file (.def) and multiple include directive changes.
For macOS an include path was missing and linkage was corrected.

Fixes #72