### PR TITLE
Improve handling of cluster scale down

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -1263,12 +1263,11 @@ static int cluster_update_route_by_addr(redisClusterContext *cc, const char *ip,
         goto error;
     }
 
-    if (cc->connect_timeout) {
-        c = redisConnectWithTimeout(ip, port, *cc->connect_timeout);
-    } else {
-        c = redisConnect(ip, port);
-    }
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_TCP(&options, ip, port);
+    options.connect_timeout = cc->connect_timeout;
 
+    c = redisConnectWithOptions(&options);
     if (c == NULL) {
         goto oom;
     }
@@ -2037,13 +2036,11 @@ redisContext *ctx_get_by_node(redisClusterContext *cc, cluster_node *node) {
         return NULL;
     }
 
-    if (cc->connect_timeout) {
-        c = redisConnectWithTimeout(node->host, node->port,
-                                    *cc->connect_timeout);
-    } else {
-        c = redisConnect(node->host, node->port);
-    }
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_TCP(&options, node->host, node->port);
+    options.connect_timeout = cc->connect_timeout;
 
+    c = redisConnectWithOptions(&options);
     if (c == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         return NULL;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,3 +180,7 @@ add_test(NAME reconnect-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/reconnect-test.sh"
                 "$<TARGET_FILE:clusterclient_reconnect_async>"
                 WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+add_test(NAME cluster-scale-down-test
+         COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/cluster-scale-down-test.sh"
+                "$<TARGET_FILE:clusterclient>"
+                WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -151,14 +151,18 @@ void test_alloc_failure_handling() {
         redisReply *reply;
         const char *cmd = "SET key value";
 
-        for (int i = 0; i < 36; ++i) {
+        for (int i = 0; i < 38; ++i) {
             prepare_allocation_test(cc, i);
             reply = (redisReply *)redisClusterCommand(cc, cmd);
             assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            if (i < 17 || i > 32) {
+                ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            } else {
+                ASSERT_STR_EQ(cc->errstr, "no reachable node in cluster");
+            }
         }
 
-        prepare_allocation_test(cc, 36);
+        prepare_allocation_test(cc, 38);
         reply = (redisReply *)redisClusterCommand(cc, cmd);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
@@ -169,15 +173,19 @@ void test_alloc_failure_handling() {
         redisReply *reply;
         const char *cmd = "MSET key1 v1 key2 v2 key3 v3";
 
-        for (int i = 0; i < 77; ++i) {
+        for (int i = 0; i < 91; ++i) {
             prepare_allocation_test(cc, i);
             reply = (redisReply *)redisClusterCommand(cc, cmd);
             assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            if (i < 49 || (i > 64 && i < 74) || i > 89) {
+                ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            } else {
+                ASSERT_STR_EQ(cc->errstr, "no reachable node in cluster");
+            }
         }
 
         // Multi-key commands
-        prepare_allocation_test(cc, 77);
+        prepare_allocation_test(cc, 91);
         reply = (redisReply *)redisClusterCommand(cc, cmd);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
@@ -192,7 +200,7 @@ void test_alloc_failure_handling() {
         assert(node);
 
         // OOM failing commands
-        for (int i = 0; i < 32; ++i) {
+        for (int i = 0; i < 33; ++i) {
             prepare_allocation_test(cc, i);
             reply = redisClusterCommandToNode(cc, node, cmd);
             assert(reply == NULL);
@@ -200,7 +208,7 @@ void test_alloc_failure_handling() {
         }
 
         // Successful command
-        prepare_allocation_test(cc, 32);
+        prepare_allocation_test(cc, 34);
         reply = redisClusterCommandToNode(cc, node, cmd);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);

--- a/tests/scripts/cluster-scale-down-test.sh
+++ b/tests/scripts/cluster-scale-down-test.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+#
+# Simulate a 3 node cluster where `nodeid3` is removed after the initial cluster
+# topology has been sent to the client. The client will attempt to connect to
+# the missing node, but due to failure the request is sent to any active node.
+# In the testcase this results in a topology refresh due to MOVED.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient}
+testname=cluster-scale-down-test
+
+# Sync processes waiting for CONT signals.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid1=$!;
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid2=$!;
+
+# Start simulated redis node #1
+timeout 5s ./simulated-redis.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 5000, ["127.0.0.1", 7401, "nodeid1"]],[5001, 10000, ["127.0.0.1", 7402, "nodeid2"]],[10001, 16383, ["127.0.0.1", 7403, "nodeid3"]]]
+EXPECT CLOSE
+EXPECT CONNECT
+EXPECT ["PING"]
+SEND +PONG
+EXPECT ["GET", "foo"]
+SEND -MOVED 12182 127.0.0.1:7402
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 8000, ["127.0.0.1", 7401, "nodeid1"]],[8001, 16383, ["127.0.0.1", 7402, "nodeid2"]]]
+EXPECT CLOSE
+EXPECT CLOSE
+EOF
+server1=$!
+
+# Start simulated redis node #2
+timeout 5s ./simulated-redis.pl -p 7402 -d --sigcont $syncpid2 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["GET", "foo"]
+SEND "bar"
+EXPECT CLOSE
+EOF
+server2=$!
+
+# Wait until both nodes are ready to accept client connections
+wait $syncpid1 $syncpid2;
+
+# Run client
+echo 'GET foo' | timeout 3s "$clientprog" 127.0.0.1:7401 > "$testname.out"
+clientexit=$?
+
+# Wait for servers to exit
+wait $server1; server1exit=$?
+wait $server2; server2exit=$?
+
+# Check exit statuses
+if [ $server1exit -ne 0 ]; then
+    echo "Simulated server #1 exited with status $server1exit"
+    exit $server1exit
+fi
+if [ $server2exit -ne 0 ]; then
+    echo "Simulated server #2 exited with status $server2exit"
+    exit $server2exit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from clusterclient
+printf 'bar\n' | cmp "$testname.out" - || exit 99
+
+# Clean up
+rm "$testname.out"


### PR DESCRIPTION
Make sure that `ctx_get_by_node()` always returns a viable connection context,
i.e. it will return a context or NULL if a connection attempt failed.
    
If `redis_cluster_command_execute()` fails to get a viable context it will attempt to find another node to send the message to.
This will will usually trigger a cluster topology update.

Added a testcase for the scenario where a node that has not previously been accessed is removed.

TODO:
- How to handle OOM errors, maybe a OOM error should bail instead of trying to create a context for the next node.
 The triggered changes in the OOM test..
