### PR TITLE
Add asynchronous transaction tests

### DIFF
--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -402,6 +402,18 @@ void test_xtrim(redisClusterContext *cc) {
     freeReplyObject(r);
 }
 
+void test_multi(redisClusterContext *cc) {
+
+    /* Since the slot lookup is currently not handled for this command
+     * the regular API is expected to fail. This command requires the
+     * ..ToNode() APIs for sending a command to a specific node.
+     * See ct_specific_nodes.c for these tests.
+     */
+
+    redisReply *r = redisClusterCommand(cc, "MULTI");
+    assert(r == NULL);
+}
+
 int main() {
     struct timeval timeout = {0, 500000};
 
@@ -414,12 +426,12 @@ int main() {
     status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
 
-    test_exists(cc);
-    test_mset(cc);
-    test_mget(cc);
-    test_hset_hget_hdel_hexists(cc);
     test_eval(cc);
-
+    test_exists(cc);
+    test_hset_hget_hdel_hexists(cc);
+    test_mget(cc);
+    test_mset(cc);
+    test_multi(cc);
     test_xack(cc);
     test_xadd(cc);
     test_xautoclaim(cc);

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -272,6 +272,7 @@ void test_pipeline_transaction(redisClusterContext *cc) {
 typedef struct ExpectedResult {
     int type;
     char *str;
+    size_t elements;
     bool disconnect;
     bool noreply;
     char *errstr;
@@ -293,8 +294,22 @@ void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
     } else {
         assert(reply != NULL);
         assert(reply->type == expect->type);
-        if (reply->type != REDIS_REPLY_INTEGER)
+        switch (reply->type) {
+        case REDIS_REPLY_ARRAY:
+            assert(reply->elements == expect->elements);
+            assert(reply->str == NULL);
+            break;
+        case REDIS_REPLY_INTEGER:
+            assert(reply->elements == 0);
+            assert(reply->str == NULL);
+            break;
+        case REDIS_REPLY_STATUS:
             assert(strcmp(reply->str, expect->str) == 0);
+            assert(reply->elements == 0);
+            break;
+        default:
+            assert(0);
+        }
     }
     if (expect->disconnect)
         redisClusterAsyncDisconnect(cc);
@@ -414,6 +429,54 @@ void test_async_to_all_nodes() {
     event_base_free(base);
 }
 
+void test_async_transaction() {
+    int status;
+
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+    redisClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    redisClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
+    redisClusterSetOptionMaxRetry(acc->cc, 1);
+    redisClusterSetOptionRouteUseSlots(acc->cc);
+    status = redisClusterConnect2(acc->cc);
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    struct event_base *base = event_base_new();
+    status = redisClusterLibeventAttach(acc, base);
+    assert(status == REDIS_OK);
+
+    cluster_node *node = redisClusterGetNodeByKey(acc->cc, "foo");
+    assert(node);
+
+    ExpectedResult r1 = {.type = REDIS_REPLY_STATUS, .str = "OK"};
+    status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
+                                            "MULTI");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    ExpectedResult r2 = {.type = REDIS_REPLY_STATUS, .str = "QUEUED"};
+    status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r2,
+                                            "SET foo 99");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    ExpectedResult r3 = {.type = REDIS_REPLY_STATUS, .str = "QUEUED"};
+    status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r3,
+                                            "INCR foo");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    /* The EXEC command will return an array with result from 2 queued commands. */
+    ExpectedResult r4 = {
+        .type = REDIS_REPLY_ARRAY, .elements = 2, .disconnect = true};
+    status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r4,
+                                            "EXEC ");
+    ASSERT_MSG(status == REDIS_OK, acc->errstr);
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+}
+
 int main() {
     int status;
 
@@ -442,6 +505,7 @@ int main() {
     test_async_to_single_node();
     test_async_formatted_to_single_node();
     test_async_to_all_nodes();
+    test_async_transaction();
 
     return 0;
 }


### PR DESCRIPTION
Add tests to verify that MULTI currently requires to be sent to a specific node and works using the async node specific API.