### PR TITLE
Add Redis compatibility testing to CI

### DIFF
--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -12,7 +12,7 @@ jobs:
         include:
           # - redis-version: 7.0.0
           - redis-version: 6.2.7
-          # - redis-version: 6.0.16
+          - redis-version: 6.0.16
           # - redis-version: 5.0.14
     steps:
       - name: Prepare

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - redis-version: 7.0.0
+          - redis-version: 7.0.0
           - redis-version: 6.2.7
           - redis-version: 6.0.16
           - redis-version: 5.0.14

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Generate makefiles
         shell: bash
-        env:
-          CC: ${{ matrix.compiler }}
         working-directory: build
         run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DTEST_WITH_REDIS_VERSION=${{ matrix.redis-version }} ..
 

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -13,7 +13,7 @@ jobs:
           # - redis-version: 7.0.0
           - redis-version: 6.2.7
           - redis-version: 6.0.16
-          # - redis-version: 5.0.14
+          - redis-version: 5.0.14
     steps:
       - name: Prepare
         run: sudo apt install libevent-dev

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -1,0 +1,56 @@
+name: Redis compatibility testing
+
+on: [push, pull_request]
+
+jobs:
+  redis-comp:
+    name: Redis ${{ matrix.redis-version }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # - redis-version: 7.0.0
+          - redis-version: 6.2.7
+          # - redis-version: 6.0.16
+          # - redis-version: 5.0.14
+    steps:
+      - name: Prepare
+        run: sudo apt install libevent-dev
+
+      - uses: actions/checkout@v3
+
+      - name: Create build folder
+        run: cmake -E make_directory build
+
+      - name: Generate makefiles
+        shell: bash
+        env:
+          CC: ${{ matrix.compiler }}
+        working-directory: build
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DTEST_WITH_REDIS_VERSION=${{ matrix.redis-version }} ..
+
+      - name: Build
+        shell: bash
+        working-directory: build
+        run: VERBOSE=1 make
+
+      - name: Setup clusters
+        shell: bash
+        working-directory: build
+        run: make start
+
+      - name: Wait for clusters to start..
+        uses: kibertoad/wait-action@1.0.1
+        with:
+          time: '40s'
+
+      - name: Run tests
+        shell: bash
+        working-directory: build
+        run: make CTEST_OUTPUT_ON_FAILURE=1 test
+
+      - name: Teardown clusters
+        working-directory: build
+        shell: bash
+        run: make stop

--- a/hircluster.c
+++ b/hircluster.c
@@ -850,7 +850,7 @@ dict *parse_cluster_slots(redisClusterContext *cc, redisReply *reply,
             } else {
                 elem_nodes = elem_slots->element[idx];
                 if (elem_nodes->type != REDIS_REPLY_ARRAY ||
-                    elem_nodes->elements != 3) {
+                    elem_nodes->elements < 2) {
                     __redisClusterSetError(
                         cc, REDIS_ERR_OTHER,
                         "Command(cluster slots) reply error: "

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(ct_commands hiredis_cluster ${SSL_LIBRARY})
 add_test(NAME ct_commands COMMAND "$<TARGET_FILE:ct_commands>")
 set_tests_properties(ct_commands PROPERTIES LABELS "CT")
 
-add_executable(ct_connection ct_connection.c)
+add_executable(ct_connection ct_connection.c test_utils.c)
 target_link_libraries(ct_connection hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_connection COMMAND "$<TARGET_FILE:ct_connection>")
 set_tests_properties(ct_connection PROPERTIES LABELS "CT")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(ct_async hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY
 add_test(NAME ct_async COMMAND "$<TARGET_FILE:ct_async>")
 set_tests_properties(ct_async PROPERTIES LABELS "CT")
 
-add_executable(ct_commands ct_commands.c)
+add_executable(ct_commands ct_commands.c test_utils.c)
 target_link_libraries(ct_commands hiredis_cluster ${SSL_LIBRARY})
 add_test(NAME ct_commands COMMAND "$<TARGET_FILE:ct_commands>")
 set_tests_properties(ct_commands PROPERTIES LABELS "CT")
@@ -87,7 +87,7 @@ target_link_libraries(ct_out_of_memory_handling hiredis_cluster ${SSL_LIBRARY} $
 add_test(NAME ct_out_of_memory_handling COMMAND "$<TARGET_FILE:ct_out_of_memory_handling>")
 set_tests_properties(ct_out_of_memory_handling PROPERTIES LABELS "CT")
 
-add_executable(ct_specific_nodes ct_specific_nodes.c)
+add_executable(ct_specific_nodes ct_specific_nodes.c test_utils.c)
 target_link_libraries(ct_specific_nodes hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME ct_specific_nodes COMMAND "$<TARGET_FILE:ct_specific_nodes>")
 set_tests_properties(ct_specific_nodes PROPERTIES LABELS "CT")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+SET(TEST_WITH_REDIS_VERSION "6.2.1" CACHE STRING "Redis version used when running tests.")
+
 if(ENABLE_SSL)
   # Generate SSL certs and keys when needed
   set(SSL_CONFIGS ca.crt ca.key ca.txt redis.crt redis.key client.crt client.key)
@@ -22,18 +24,15 @@ else()
   set(NO_IPV6 "true") # Ignore command
 endif()
 
-find_program(Docker_EXECUTABLE docker)
-set(CONTAINER "bjosv/redis-cluster:6.2.0") # When supporting password change to: grokzen/redis-cluster:X.X.X
-
 add_custom_target(start
-  COMMAND ${Docker_EXECUTABLE} run --name docker-cluster -d -p 7000-7006:7000-7006 ${CONTAINER} || (exit 0)
-  COMMAND ${Docker_EXECUTABLE} run --name docker-cluster-passw -d -e INITIAL_PORT=7100 -e PASSWORD="secretword" -p 7100-7106:7100-7106 ${CONTAINER} || (exit 0)
-  COMMAND ${NO_IPV6} ${Docker_EXECUTABLE} run --name docker-cluster-ipv6 -d -e INITIAL_PORT=7200 -e IP=:: -e BIND_ADDRESS=::1 --network host ${CONTAINER} || (exit 0)
-)
+  COMMAND REDIS_VERSION=${TEST_WITH_REDIS_VERSION} PORT=7000 ${CMAKE_SOURCE_DIR}/tests/scripts/redis-cluster start
+  COMMAND REDIS_VERSION=${TEST_WITH_REDIS_VERSION} PORT=7100 ADDITIONAL_OPTIONS='--requirepass secretword --masterauth secretword' ADDITIONAL_CLI_OPTIONS='-a secretword' ${CMAKE_SOURCE_DIR}/tests/scripts/redis-cluster start
+  COMMAND ${NO_IPV6} REDIS_VERSION=${TEST_WITH_REDIS_VERSION} PORT=7200 CLUSTER_HOST=::1 ADDITIONAL_OPTIONS='--bind ::1' ADDITIONAL_CLI_OPTIONS='-h ::1' ${CMAKE_SOURCE_DIR}/tests/scripts/redis-cluster start
+  )
 add_custom_target(stop
-  COMMAND ${Docker_EXECUTABLE} rm -f  docker-cluster || (exit 0)
-  COMMAND ${Docker_EXECUTABLE} rm -f  docker-cluster-passw || (exit 0)
-  COMMAND ${NO_IPV6} ${Docker_EXECUTABLE} rm -f  docker-cluster-ipv6 || (exit 0)
+  COMMAND PORT=7000 ${CMAKE_SOURCE_DIR}/tests/scripts/redis-cluster stop
+  COMMAND PORT=7100 ${CMAKE_SOURCE_DIR}/tests/scripts/redis-cluster stop
+  COMMAND ${NO_IPV6} PORT=7200 ${CMAKE_SOURCE_DIR}/tests/scripts/redis-cluster stop
 )
 
 # Find dependencies

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -218,7 +218,11 @@ void test_eval(redisClusterContext *cc) {
 
     reply = (redisReply *)redisClusterCommand(
         cc, "eval %s 1 %s", "return redis.call('get',KEYS[1])", "foo");
-    CHECK_REPLY_ERROR(cc, reply, "ERR Error running script");
+    if (redis_version_less_than(7, 0)) {
+        CHECK_REPLY_ERROR(cc, reply, "ERR Error running script");
+    } else {
+        CHECK_REPLY_ERROR(cc, reply, "WRONGTYPE");
+    }
     freeReplyObject(reply);
 
     // Two keys handled by different instances,

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -466,7 +466,7 @@ int main() {
     int status;
     status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
-    get_redis_version(cc);
+    load_redis_version(cc);
 
     test_bitfield(cc);
     test_bitfield_ro(cc);

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -42,6 +42,9 @@ void test_bitfield(redisClusterContext *cc) {
 }
 
 void test_bitfield_ro(redisClusterContext *cc) {
+    if (redis_version_less_than(6, 0))
+        return; /* Skip test, command not available. */
+
     redisReply *reply;
 
     reply = (redisReply *)redisClusterCommand(cc, "SET bkey2 a"); // 97
@@ -363,10 +366,12 @@ void test_xinfo(redisClusterContext *cc) {
     CHECK_REPLY_TYPE(r, REDIS_REPLY_ARRAY);
     freeReplyObject(r);
 
-    /* Test of subcommand STREAM with arguments*/
-    r = redisClusterCommand(cc, "XINFO STREAM mystream FULL COUNT 1");
-    CHECK_REPLY_TYPE(r, REDIS_REPLY_ARRAY);
-    freeReplyObject(r);
+    if (!redis_version_less_than(6, 0)) {
+        /* Test of subcommand STREAM with arguments when available. */
+        r = redisClusterCommand(cc, "XINFO STREAM mystream FULL COUNT 1");
+        CHECK_REPLY_TYPE(r, REDIS_REPLY_ARRAY);
+        freeReplyObject(r);
+    }
 
     r = redisClusterCommand(cc, "XINFO GROUPS mystream");
     CHECK_REPLY_TYPE(r, REDIS_REPLY_ARRAY);

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -24,6 +24,7 @@ void test_password_ok() {
     int status;
     status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    get_redis_version(cc);
 
     // Test connection
     redisReply *reply;
@@ -47,7 +48,10 @@ void test_password_wrong() {
     assert(status == REDIS_ERR);
 
     assert(cc->err == REDIS_ERR_OTHER);
-    assert(strncmp(cc->errstr, "WRONGPASS", 9) == 0);
+    if (redis_version_less_than(6, 0))
+        assert(strcmp(cc->errstr, "ERR invalid password") == 0);
+    else
+        assert(strncmp(cc->errstr, "WRONGPASS", 9) == 0);
 
     redisClusterFree(cc);
 }
@@ -73,6 +77,8 @@ void test_password_missing() {
 // Connect to a cluster and authenticate using username and password,
 // i.e. 'AUTH <username> <password>'
 void test_username_ok() {
+    if (redis_version_less_than(6, 0))
+        return;
 
     // Connect to the cluster using username and password
     redisClusterContext *cc = redisClusterContextInit();
@@ -94,6 +100,9 @@ void test_username_ok() {
 
 // Test of disabling the use of username after it was enabled.
 void test_username_disabled() {
+    if (redis_version_less_than(6, 0))
+        return;
+
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
     redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
@@ -356,7 +365,10 @@ void test_async_password_wrong() {
     assert(ret == REDIS_ERR);
     assert(acc->err == REDIS_OK); // TODO: This must be wrong!
     assert(acc->cc->err == REDIS_ERR_OTHER);
-    assert(strncmp(acc->cc->errstr, "WRONGPASS", 6) == 0);
+    if (redis_version_less_than(6, 0))
+        assert(strcmp(acc->cc->errstr, "ERR invalid password") == 0);
+    else
+        assert(strncmp(acc->cc->errstr, "WRONGPASS", 9) == 0);
 
     // No connection
     ExpectedResult r;
@@ -406,6 +418,8 @@ void test_async_password_missing() {
 
 // Connect to a cluster and authenticate using username and password
 void test_async_username_ok() {
+    if (redis_version_less_than(6, 0))
+        return;
 
     // Connect to the cluster using username and password
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -24,7 +24,7 @@ void test_password_ok() {
     int status;
     status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
-    get_redis_version(cc);
+    load_redis_version(cc);
 
     // Test connection
     redisReply *reply;

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -195,7 +195,7 @@ void test_connect_timeout() {
 
 /* Connect using a pre-configured command timeout */
 void test_command_timeout() {
-    struct timeval timeout = {0, 200000};
+    struct timeval timeout = {0, 10000};
 
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
@@ -212,16 +212,25 @@ void test_command_timeout() {
 
     /* Simulate a command timeout */
     redisReply *reply;
-    reply = redisClusterCommandToNode(cc, node, "DEBUG SLEEP 1");
+    reply = redisClusterCommandToNode(cc, node, "DEBUG SLEEP 0.2");
     assert(reply == NULL);
     assert(cc->err == REDIS_ERR_IO);
+
+    /* Make sure debug sleep is done before leaving testcase */
+    for (int i = 0; i < 20; ++i) {
+        reply = redisClusterCommandToNode(cc, node, "SET key1 Hello");
+        if (reply && reply->type == REDIS_REPLY_STATUS)
+            break;
+    }
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
 
     redisClusterFree(cc);
 }
 
 /* Connect and configure a command timeout while connected. */
 void test_command_timeout_set_while_connected() {
-    struct timeval timeout = {0, 200000};
+    struct timeval timeout = {0, 10000};
 
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
@@ -236,16 +245,26 @@ void test_command_timeout_set_while_connected() {
     assert(node);
 
     redisReply *reply;
-    reply = redisClusterCommandToNode(cc, node, "DEBUG SLEEP 1");
+    reply = redisClusterCommandToNode(cc, node, "DEBUG SLEEP 0.2");
     CHECK_REPLY_OK(cc, reply);
     freeReplyObject(reply);
 
     /* Set command timeout while connected */
     redisClusterSetOptionTimeout(cc, timeout);
 
-    reply = redisClusterCommandToNode(cc, node, "DEBUG SLEEP 1");
+    reply = redisClusterCommandToNode(cc, node, "DEBUG SLEEP 0.2");
     assert(reply == NULL);
     assert(cc->err == REDIS_ERR_IO);
+
+    /* Make sure debug sleep is done before leaving testcase */
+    for (int i = 0; i < 20; ++i) {
+        reply = redisClusterCommandToNode(cc, node, "SET key1 Hello");
+        if (reply && reply->type == REDIS_REPLY_STATUS)
+            break;
+    }
+    CHECK_REPLY_OK(cc, reply);
+    freeReplyObject(reply);
+
     redisClusterFree(cc);
 }
 
@@ -522,7 +541,7 @@ void test_async_connect_timeout() {
 
 /* Connect using a pre-configured command timeout */
 void test_async_command_timeout() {
-    struct timeval timeout = {0, 200000};
+    struct timeval timeout = {0, 10000};
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
     assert(acc);
@@ -545,7 +564,7 @@ void test_async_command_timeout() {
     ExpectedResult r = {
         .noreply = true, .errstr = "Timeout", .disconnect = true};
     status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r,
-                                            "DEBUG SLEEP 1");
+                                            "DEBUG SLEEP 0.2");
     assert(status == REDIS_OK);
 
     event_base_dispatch(base);

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -158,11 +158,13 @@ void test_streams(redisClusterContext *cc) {
     CHECK_REPLY_OK(cc, reply);
     freeReplyObject(reply);
 
-    /* Create a consumer */
-    reply = redisClusterCommandToNode(
-        cc, node, "XGROUP CREATECONSUMER mystream mygroup1 myconsumer123");
-    CHECK_REPLY_INT(cc, reply, 1);
-    freeReplyObject(reply);
+    if (!redis_version_less_than(6, 2)) {
+        /* Create a consumer */
+        reply = redisClusterCommandToNode(
+            cc, node, "XGROUP CREATECONSUMER mystream mygroup1 myconsumer123");
+        CHECK_REPLY_INT(cc, reply, 1);
+        freeReplyObject(reply);
+    }
 
     /* Blocking read of consumer group */
     reply = redisClusterCommandToNode(cc, node,
@@ -487,6 +489,7 @@ int main() {
     redisClusterSetOptionMaxRetry(cc, 1);
     status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
+    get_redis_version(cc);
 
     // Synchronous API
     test_command_to_single_node(cc);

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -489,7 +489,7 @@ int main() {
     redisClusterSetOptionMaxRetry(cc, 1);
     status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
-    get_redis_version(cc);
+    load_redis_version(cc);
 
     // Synchronous API
     test_command_to_single_node(cc);

--- a/tests/scripts/redis-cluster
+++ b/tests/scripts/redis-cluster
@@ -10,6 +10,11 @@ REPLICAS=${REPLICAS:-1}
 ADDITIONAL_OPTIONS=${ADDITIONAL_OPTIONS:-""}
 ADDITIONAL_CLI_OPTIONS=${ADDITIONAL_CLI_OPTIONS:-""}
 
+# Version specific options
+if [[ $REDIS_VERSION == 7* ]]; then
+    ADDITIONAL_OPTIONS="--enable-debug-command yes ${ADDITIONAL_OPTIONS}"
+fi
+
 if [ "$1" == "start" ]; then
     FIRST_PORT=${PORT}
     HOSTS=""

--- a/tests/scripts/redis-cluster
+++ b/tests/scripts/redis-cluster
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Settings
+REDIS_VERSION=${REDIS_VERSION:-"6.2.1"}
+CLUSTER_HOST=${CLUSTER_HOST:-127.0.0.1}
+PORT=${PORT:-30000}
+TIMEOUT=${TIMEOUT:-2000}
+NODES=${NODES:-6}
+REPLICAS=${REPLICAS:-1}
+ADDITIONAL_OPTIONS=${ADDITIONAL_OPTIONS:-""}
+ADDITIONAL_CLI_OPTIONS=${ADDITIONAL_CLI_OPTIONS:-""}
+
+if [ "$1" == "start" ]
+then
+    FIRST_PORT=${PORT}
+    HOSTS=""
+    for i in $(seq $NODES); do
+        echo "Starting redis:${REDIS_VERSION} on port $PORT..."
+        docker run --name redis-${PORT} --net=host -d redis:${REDIS_VERSION} redis-server --cluster-enabled yes --port ${PORT} --cluster-node-timeout ${TIMEOUT} ${ADDITIONAL_OPTIONS}
+        HOSTS="$HOSTS $CLUSTER_HOST:$PORT"
+        PORT=$((PORT+1))
+    done
+
+    sleep 20
+
+    echo 'yes' | docker run --name redis-cli --net=host -i --rm redis:${REDIS_VERSION} redis-cli -p ${FIRST_PORT} ${ADDITIONAL_CLI_OPTIONS} --cluster create ${HOSTS} --cluster-replicas ${REPLICAS}
+    exit 0
+fi
+
+if [ "$1" == "stop" ]
+then
+    for i in $(seq $NODES); do
+        echo "Stopping redis on port $PORT..."
+        docker rm -f redis-${PORT} &> /dev/null
+        PORT=$((PORT+1))
+    done
+    exit 0
+fi
+
+echo "Usage: $0 [start|stop]"
+echo "start       -- Start Redis Cluster instances."
+echo "stop        -- Stop Redis Cluster instances."

--- a/tests/scripts/redis-cluster
+++ b/tests/scripts/redis-cluster
@@ -10,8 +10,7 @@ REPLICAS=${REPLICAS:-1}
 ADDITIONAL_OPTIONS=${ADDITIONAL_OPTIONS:-""}
 ADDITIONAL_CLI_OPTIONS=${ADDITIONAL_CLI_OPTIONS:-""}
 
-if [ "$1" == "start" ]
-then
+if [ "$1" == "start" ]; then
     FIRST_PORT=${PORT}
     HOSTS=""
     for i in $(seq $NODES); do
@@ -27,8 +26,7 @@ then
     exit 0
 fi
 
-if [ "$1" == "stop" ]
-then
+if [ "$1" == "stop" ]; then
     for i in $(seq $NODES); do
         echo "Stopping redis on port $PORT..."
         docker rm -f redis-${PORT} &> /dev/null

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -9,7 +9,7 @@ static int redis_version_minor;
 
 /* Helper to extract Redis version information. */
 #define REDIS_VERSION_FIELD "redis_version:"
-void get_redis_version(redisClusterContext *cc) {
+void load_redis_version(redisClusterContext *cc) {
     nodeIterator ni;
     cluster_node *node;
     char *eptr, *s, *e;
@@ -49,7 +49,7 @@ abort:
 /* Helper to verify Redis version information. */
 int redis_version_less_than(int major, int minor) {
     if (redis_version_major == 0) {
-        fprintf(stderr, "Error: Redis version not fetched, aborting..\n");
+        fprintf(stderr, "Error: Redis version not loaded, aborting..\n");
         exit(1);
     }
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -1,0 +1,61 @@
+#include "hircluster.h"
+
+#include "test_utils.h"
+#include <stdlib.h>
+#include <string.h>
+
+static int redis_version_major;
+static int redis_version_minor;
+
+/* Helper to extract Redis version information. */
+#define REDIS_VERSION_FIELD "redis_version:"
+void get_redis_version(redisClusterContext *cc) {
+    nodeIterator ni;
+    cluster_node *node;
+    char *eptr, *s, *e;
+    redisReply *reply = NULL;
+
+    initNodeIterator(&ni, cc);
+    if ((node = nodeNext(&ni)) == NULL)
+        goto abort;
+
+    reply = redisClusterCommandToNode(cc, node, "INFO");
+    if (reply == NULL || cc->err || reply->type != REDIS_REPLY_STRING)
+        goto abort;
+    if ((s = strstr(reply->str, REDIS_VERSION_FIELD)) == NULL)
+        goto abort;
+
+    s += strlen(REDIS_VERSION_FIELD);
+
+    /* We need a field terminator and at least 'x.y.z' (5) bytes of data */
+    if ((e = strstr(s, "\r\n")) == NULL || (e - s) < 5)
+        goto abort;
+
+    /* Extract version info */
+    redis_version_major = strtol(s, &eptr, 10);
+    if (*eptr != '.')
+        goto abort;
+    redis_version_minor = strtol(eptr + 1, NULL, 10);
+
+    freeReplyObject(reply);
+    return;
+
+abort:
+    freeReplyObject(reply);
+    fprintf(stderr, "Error: Cannot get Redis version, aborting..\n");
+    exit(1);
+}
+
+/* Helper to verify Redis version information. */
+int redis_version_less_than(int major, int minor) {
+    if (redis_version_major == 0) {
+        fprintf(stderr, "Error: Redis version not fetched, aborting..\n");
+        exit(1);
+    }
+
+    if (redis_version_major < major)
+        return 1;
+    if (redis_version_major == major && redis_version_minor < minor)
+        return 1;
+    return 0;
+}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -70,3 +70,8 @@
     { assert(strncmp(_s1, _s2, strlen(_s2)) == 0); }
 
 #endif
+
+struct redisClusterContext;
+
+void get_redis_version(redisClusterContext *cc);
+int redis_version_less_than(int major, int minor);

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -73,5 +73,5 @@
 
 struct redisClusterContext;
 
-void get_redis_version(redisClusterContext *cc);
+void load_redis_version(redisClusterContext *cc);
 int redis_version_less_than(int major, int minor);


### PR DESCRIPTION
Run all tests on different Redis versions by setting up the cluster using containers.
Currently version `5.0.14`, `6.0.16`, `6.2.7` and `7.0.0` are tested,
but adding a new version is simple due to that official Redis containers are used.

Versions 5.0 and 6.0 required some test-cases to be skipped, due to used commands were added more recently.
Version 7.0 required a correction while parsing `CLUSTER SLOTS` and additional configuration.

While running tests an intermittent issue regarding `DEBUG SLEEP` was found and fixed.
