### PR TITLE
Remove usage of hiredis internal flags

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -3360,14 +3360,12 @@ static int redisClusterSendAll(redisClusterContext *cc) {
             continue;
         }
 
-        if (c->flags & REDIS_BLOCK) {
-            /* Write until done */
-            do {
-                if (redisBufferWrite(c, &wdone) == REDIS_ERR) {
-                    return REDIS_ERR;
-                }
-            } while (!wdone);
-        }
+        /* Write until done */
+        do {
+            if (redisBufferWrite(c, &wdone) == REDIS_ERR) {
+                return REDIS_ERR;
+            }
+        } while (!wdone);
     }
 
     return REDIS_OK;
@@ -3530,8 +3528,10 @@ void redisClusterReset(redisClusterContext *cc) {
     if (cc->err) {
         redisClusterClearAll(cc);
     } else {
+        /* Write/flush each nodes output buffer to socket */
         redisClusterSendAll(cc);
 
+        /* Expect a reply for each pipelined request */
         do {
             status = redisClusterGetReply(cc, &reply);
             if (status == REDIS_OK) {

--- a/hircluster.c
+++ b/hircluster.c
@@ -1910,8 +1910,7 @@ int redisClusterSetOptionTimeout(redisClusterContext *cc,
                 if (node->acon) {
                     redisAsyncSetTimeout(node->acon, tv);
                 }
-                if (node->con && node->con->flags & REDIS_CONNECTED &&
-                    node->con->err == 0) {
+                if (node->con && node->con->err == 0) {
                     redisSetTimeout(node->con, tv);
                 }
 
@@ -1927,8 +1926,7 @@ int redisClusterSetOptionTimeout(redisClusterContext *cc,
                         if (slave->acon) {
                             redisAsyncSetTimeout(slave->acon, tv);
                         }
-                        if (slave->con && slave->con->flags & REDIS_CONNECTED &&
-                            slave->con->err == 0) {
+                        if (slave->con && slave->con->err == 0) {
                             redisSetTimeout(slave->con, tv);
                         }
                     }


### PR DESCRIPTION
Remove use of:
REDIS_BLOCK
REDIS_CONNECTED

initially added by `hiredis-vip` due to its non-block socket use, which later was changed.