### PR TITLE
Build examples updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,8 @@ add_library(hiredis_cluster
   ${hiredis_cluster_sources})
 
 if(NOT MSVC)
-  target_compile_options(hiredis_cluster PRIVATE -Wall -Wextra -pedantic -Werror)
+  target_compile_options(hiredis_cluster PRIVATE -Wall -Wextra -pedantic -Werror
+    -Wstrict-prototypes -Wwrite-strings)
 
   # Add extra defines when CMAKE_BUILD_TYPE is set to Debug
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DHI_ASSERT_PANIC -DHI_HAVE_BACKTRACE")

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo 
 OPTIMIZATION?=-O3
 WARNINGS=-Wall -Wextra -pedantic -Werror -Wstrict-prototypes -Wwrite-strings
 DEBUG_FLAGS?= -g -ggdb
-REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
+REAL_CFLAGS=$(OPTIMIZATION) -std=c99 -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
 REAL_LDFLAGS=$(LDFLAGS)
 
 DYLIBSUFFIX=so
@@ -72,7 +72,7 @@ endif
 
 all: $(DYLIBNAME) $(SSL_DYLIBNAME) $(STLIBNAME) $(SSL_STLIBNAME) $(PKGCONFNAME) $(SSL_PKGCONFNAME)
 
-# Deps (use make dep to generate this)
+# Deps (use `USE_SSL=1 make dep` to generate this)
 adlist.o: adlist.c adlist.h hiutil.h
 command.o: command.c command.h adlist.h hiarray.h hiutil.h win32.h
 crc16.o: crc16.c hiutil.h
@@ -109,7 +109,7 @@ hiredis-cluster-example-tls: examples/src/example_tls.c
 examples: $(EXAMPLES)
 
 .c.o:
-	$(CC) -std=c99 -c $(REAL_CFLAGS) $<
+	$(CC) -c $(REAL_CFLAGS) $<
 
 clean:
 	rm -rf $(DYLIBNAME) $(STLIBNAME) $(SSL_DYLIBNAME) $(SSL_STLIBNAME) $(PKGCONFNAME) $(SSL_PKGCONFNAME) examples/hiredis-cluster-example* *.o *.gcda *.gcno *.gcov

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ INSTALL_PKGCONF_PATH= $(INSTALL_LIBRARY_PATH)/$(PKGCONF_PATH)
 # Fallback to gcc when $CC is not in $PATH.
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 OPTIMIZATION?=-O3
-WARNINGS=-Wall -W -Wstrict-prototypes -Wwrite-strings
+WARNINGS=-Wall -Wextra -pedantic -Werror -Wstrict-prototypes -Wwrite-strings
 DEBUG_FLAGS?= -g -ggdb
 REAL_CFLAGS=$(OPTIMIZATION) -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
 REAL_LDFLAGS=$(LDFLAGS)
@@ -109,7 +109,7 @@ hiredis-cluster-example-tls: examples/src/example_tls.c
 examples: $(EXAMPLES)
 
 .c.o:
-	$(CC) -std=c99 -pedantic -c $(REAL_CFLAGS) $<
+	$(CC) -std=c99 -c $(REAL_CFLAGS) $<
 
 clean:
 	rm -rf $(DYLIBNAME) $(STLIBNAME) $(SSL_DYLIBNAME) $(SSL_STLIBNAME) $(PKGCONFNAME) $(SSL_PKGCONFNAME) examples/hiredis-cluster-example* *.o *.gcda *.gcno *.gcov

--- a/examples/using_cmake_externalproject/CMakeLists.txt
+++ b/examples/using_cmake_externalproject/CMakeLists.txt
@@ -5,7 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(hiredis
   PREFIX hiredis
   GIT_REPOSITORY  https://github.com/redis/hiredis
-  GIT_TAG         v1.0.0
+  GIT_TAG         v1.0.2
   CMAKE_ARGS
     "-DCMAKE_C_FLAGS:STRING=-std=c99"
     "-DENABLE_SSL:BOOL=ON"

--- a/examples/using_cmake_separate/build.sh
+++ b/examples/using_cmake_separate/build.sh
@@ -9,7 +9,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.0.0
+hiredis_version=1.0.2
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using CMake

--- a/examples/using_make/build.sh
+++ b/examples/using_make/build.sh
@@ -8,7 +8,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.0.0
+hiredis_version=1.0.2
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using GNU Make


### PR DESCRIPTION
* Use pedantic warnings for examples.
* Use c99 when building the examples too.
* Update hiredis version in the build examples.
* Build warnings are now equal in both Make and CMake builds.


