### PR TITLE
Connect refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(hiredis_cluster
 
 if(NOT MSVC)
   target_compile_options(hiredis_cluster PRIVATE -Wall -Wextra -pedantic -Werror
-    -Wstrict-prototypes -Wwrite-strings)
+    -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers)
 
   # Add extra defines when CMAKE_BUILD_TYPE is set to Debug
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DHI_ASSERT_PANIC -DHI_HAVE_BACKTRACE")

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ INSTALL_PKGCONF_PATH= $(INSTALL_LIBRARY_PATH)/$(PKGCONF_PATH)
 # Fallback to gcc when $CC is not in $PATH.
 CC:=$(shell sh -c 'type $${CC%% *} >/dev/null 2>/dev/null && echo $(CC) || echo gcc')
 OPTIMIZATION?=-O3
-WARNINGS=-Wall -Wextra -pedantic -Werror -Wstrict-prototypes -Wwrite-strings
+WARNINGS=-Wall -Wextra -pedantic -Werror -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers
 DEBUG_FLAGS?= -g -ggdb
 REAL_CFLAGS=$(OPTIMIZATION) -std=c99 -fPIC $(CFLAGS) $(WARNINGS) $(DEBUG_FLAGS)
 REAL_LDFLAGS=$(LDFLAGS)

--- a/hircluster.c
+++ b/hircluster.c
@@ -1241,22 +1241,18 @@ static int cluster_update_route_by_addr(redisClusterContext *cc, const char *ip,
         goto error;
     }
 
-    if (cc->connect_timeout) {
-        c = redisConnectWithTimeout(ip, port, *cc->connect_timeout);
-    } else {
-        c = redisConnect(ip, port);
-    }
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_TCP(&options, ip, port);
+    options.connect_timeout = cc->connect_timeout;
+    options.command_timeout = cc->command_timeout;
 
+    c = redisConnectWithOptions(&options);
     if (c == NULL) {
         goto oom;
     }
     if (c->err) {
         __redisClusterSetError(cc, c->err, c->errstr);
         goto error;
-    }
-
-    if (cc->command_timeout) {
-        redisSetTimeout(c, *cc->command_timeout);
     }
 
     if (cc->ssl && cc->ssl_init_fn(c, cc->ssl) != REDIS_OK) {
@@ -1987,13 +1983,12 @@ redisContext *ctx_get_by_node(redisClusterContext *cc, cluster_node *node) {
         return NULL;
     }
 
-    if (cc->connect_timeout) {
-        c = redisConnectWithTimeout(node->host, node->port,
-                                    *cc->connect_timeout);
-    } else {
-        c = redisConnect(node->host, node->port);
-    }
+    redisOptions options = {0};
+    REDIS_OPTIONS_SET_TCP(&options, node->host, node->port);
+    options.connect_timeout = cc->connect_timeout;
+    options.command_timeout = cc->command_timeout;
 
+    c = redisConnectWithOptions(&options);
     if (c == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         return NULL;
@@ -2003,10 +1998,6 @@ redisContext *ctx_get_by_node(redisClusterContext *cc, cluster_node *node) {
         __redisClusterSetError(cc, c->err, c->errstr);
         redisFree(c);
         return NULL;
-    }
-
-    if (cc->command_timeout) {
-        redisSetTimeout(c, *cc->command_timeout);
     }
 
     if (cc->ssl && cc->ssl_init_fn(c, cc->ssl) != REDIS_OK) {

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -135,13 +135,13 @@ void test_alloc_failure_handling() {
 
     // Connect
     {
-        for (int i = 0; i < 129; ++i) {
+        for (int i = 0; i < 130; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterConnect2(cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(cc, 129);
+        prepare_allocation_test(cc, 130);
         result = redisClusterConnect2(cc);
         assert(result == REDIS_OK);
     }
@@ -211,7 +211,7 @@ void test_alloc_failure_handling() {
         redisReply *reply;
         const char *cmd = "SET foo one";
 
-        for (int i = 0; i < 36; ++i) {
+        for (int i = 0; i < 37; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterAppendCommand(cc, cmd);
             assert(result == REDIS_ERR);
@@ -223,7 +223,7 @@ void test_alloc_failure_handling() {
         for (int i = 0; i < 4; ++i) {
             // Appended command lost when receiving error from hiredis
             // during a GetReply, needs a new append for each test loop
-            prepare_allocation_test(cc, 36);
+            prepare_allocation_test(cc, 37);
             result = redisClusterAppendCommand(cc, cmd);
             assert(result == REDIS_OK);
 
@@ -235,7 +235,7 @@ void test_alloc_failure_handling() {
             redisClusterReset(cc);
         }
 
-        prepare_allocation_test(cc, 36);
+        prepare_allocation_test(cc, 37);
         result = redisClusterAppendCommand(cc, cmd);
         assert(result == REDIS_OK);
 
@@ -251,7 +251,7 @@ void test_alloc_failure_handling() {
         redisReply *reply;
         const char *cmd = "MSET key1 val1 key2 val2 key3 val3";
 
-        for (int i = 0; i < 88; ++i) {
+        for (int i = 0; i < 90; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterAppendCommand(cc, cmd);
             assert(result == REDIS_ERR);
@@ -261,7 +261,7 @@ void test_alloc_failure_handling() {
         }
 
         for (int i = 0; i < 12; ++i) {
-            prepare_allocation_test(cc, 88);
+            prepare_allocation_test(cc, 90);
             result = redisClusterAppendCommand(cc, cmd);
             assert(result == REDIS_OK);
 
@@ -273,7 +273,7 @@ void test_alloc_failure_handling() {
             redisClusterReset(cc);
         }
 
-        prepare_allocation_test(cc, 88);
+        prepare_allocation_test(cc, 90);
         result = redisClusterAppendCommand(cc, cmd);
         assert(result == REDIS_OK);
 
@@ -293,7 +293,7 @@ void test_alloc_failure_handling() {
         assert(node);
 
         // OOM failing appends
-        for (int i = 0; i < 36; ++i) {
+        for (int i = 0; i < 37; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterAppendCommandToNode(cc, node, cmd);
             assert(result == REDIS_ERR);
@@ -305,7 +305,7 @@ void test_alloc_failure_handling() {
         // OOM failing GetResults
         for (int i = 0; i < 4; ++i) {
             // First a successful append
-            prepare_allocation_test(cc, 36);
+            prepare_allocation_test(cc, 37);
             result = redisClusterAppendCommandToNode(cc, node, cmd);
             assert(result == REDIS_OK);
 
@@ -318,7 +318,7 @@ void test_alloc_failure_handling() {
         }
 
         // Successful append and GetReply
-        prepare_allocation_test(cc, 36);
+        prepare_allocation_test(cc, 37);
         result = redisClusterAppendCommandToNode(cc, node, cmd);
         assert(result == REDIS_OK);
 


### PR DESCRIPTION
Connect using redisConnectWithOptions() to set timeout values at the same time.
This requires disabling `missing-field-initializers` warnings, which match how its done in `redis` and `hiredis`.