### PR TITLE
No command retries due to CROSSSLOT

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -53,7 +53,6 @@
 #define REDIS_ERROR_MOVED "MOVED"
 #define REDIS_ERROR_ASK "ASK"
 #define REDIS_ERROR_TRYAGAIN "TRYAGAIN"
-#define REDIS_ERROR_CROSSSLOT "CROSSSLOT"
 #define REDIS_ERROR_CLUSTERDOWN "CLUSTERDOWN"
 
 #define REDIS_STATUS_OK "OK"
@@ -90,7 +89,6 @@ typedef enum CLUSTER_ERR_TYPE {
     CLUSTER_ERR_MOVED,
     CLUSTER_ERR_ASK,
     CLUSTER_ERR_TRYAGAIN,
-    CLUSTER_ERR_CROSSSLOT,
     CLUSTER_ERR_CLUSTERDOWN,
     CLUSTER_ERR_SENTINEL
 } CLUSTER_ERR_TYPE;
@@ -242,10 +240,6 @@ static int cluster_reply_error_type(redisReply *reply) {
                    strncmp(reply->str, REDIS_ERROR_TRYAGAIN,
                            strlen(REDIS_ERROR_TRYAGAIN)) == 0) {
             return CLUSTER_ERR_TRYAGAIN;
-        } else if ((int)strlen(REDIS_ERROR_CROSSSLOT) < reply->len &&
-                   strncmp(reply->str, REDIS_ERROR_CROSSSLOT,
-                           strlen(REDIS_ERROR_CROSSSLOT)) == 0) {
-            return CLUSTER_ERR_CROSSSLOT;
         } else if ((int)strlen(REDIS_ERROR_CLUSTERDOWN) < reply->len &&
                    strncmp(reply->str, REDIS_ERROR_CLUSTERDOWN,
                            strlen(REDIS_ERROR_CLUSTERDOWN)) == 0) {
@@ -2433,7 +2427,6 @@ ask_retry:
 
             break;
         case CLUSTER_ERR_TRYAGAIN:
-        case CLUSTER_ERR_CROSSSLOT:
         case CLUSTER_ERR_CLUSTERDOWN:
             freeReplyObject(reply);
             reply = NULL;
@@ -3989,7 +3982,6 @@ static void redisClusterAsyncRetryCallback(redisAsyncContext *ac, void *r,
 
             break;
         case CLUSTER_ERR_TRYAGAIN:
-        case CLUSTER_ERR_CROSSSLOT:
         case CLUSTER_ERR_CLUSTERDOWN:
             ac_retry = ac;
 

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -226,11 +226,12 @@ void test_eval(redisClusterContext *cc) {
     freeReplyObject(reply);
 
     // Two keys handled by different instances,
-    // will be retried multiple times and fail due to CROSSSLOT.
+    // will fail due to CROSSSLOT.
     reply = (redisReply *)redisClusterCommand(
         cc, "eval %s 2 %s %s %s %s", "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
         "key1", "key2", "first", "second");
-    assert(reply == NULL);
+    CHECK_REPLY_ERROR(cc, reply, "CROSSSLOT");
+    freeReplyObject(reply);
 }
 
 void test_xack(redisClusterContext *cc) {


### PR DESCRIPTION
There is no reason to retry a request when it contains multiple keys that don't belong to the same hash slot.