### PR TITLE
Fix problems during async node disconnects

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -3637,8 +3637,11 @@ redisAsyncContext *actx_get_by_node(redisClusterAsyncContext *acc,
         if (ac->c.err == 0) {
             return ac;
         } else {
-            /* Disconnect ongoing and __redisAsyncDisconnect() will eventually */
-            /* call unlinkAsyncContextAndNode() before freeing the context.    */
+            /* The cluster node has a hiredis context with errors. Hiredis
+             * will asynchronously destruct the context and unlink it from
+             * the cluster node object. Return an error until done.
+             * An example scenario is when sending a command from a command
+             * callback, which has a NULL reply due to a disconnect. */
             __redisClusterAsyncSetError(acc, ac->c.err, ac->c.errstr);
             return NULL;
         }

--- a/hircluster.c
+++ b/hircluster.c
@@ -280,8 +280,8 @@ static void cluster_node_deinit(cluster_node *node) {
     node->con = NULL;
 
     if (node->acon != NULL) {
-        /* Since the cluster node is deleted the async context should not update */
-        /* the cluster_node via it's dataCleanup and unlinkAsyncContextAndNode() */
+        /* Since the cluster node is deleted the async context should not update
+         * the cluster_node via it's dataCleanup and unlinkAsyncContextAndNode() */
         node->acon->data = NULL;
         redisAsyncFree(node->acon);
     }

--- a/hircluster.c
+++ b/hircluster.c
@@ -1387,8 +1387,8 @@ static int cluster_update_route_by_addr(redisClusterContext *cc, const char *ip,
     // Move all hiredis contexts in cc->nodes to nodes
     cluster_nodes_swap_ctx(cc->nodes, nodes);
 
-    /* Replace cc->nodes before releasing the old dict since */
-    /* the release procedure might access cc->nodes. */
+    /* Replace cc->nodes before releasing the old dict since
+     * the release procedure might access cc->nodes. */
     oldnodes = cc->nodes;
     cc->nodes = nodes;
     if (oldnodes != NULL) {

--- a/hircluster.c
+++ b/hircluster.c
@@ -280,6 +280,9 @@ static void cluster_node_deinit(cluster_node *node) {
     node->con = NULL;
 
     if (node->acon != NULL) {
+        /* Since the cluster node is deleted the async context should not update */
+        /* the cluster_node via it's dataCleanup and unlinkAsyncContextAndNode() */
+        node->acon->data = NULL;
         redisAsyncFree(node->acon);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,12 +165,10 @@ add_test(NAME moved-redirect-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/moved-redirect-test.sh"
                  "$<TARGET_FILE:clusterclient>"
                  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
-# The test "moved-redirect-test-async" below triggers a warning when running
-# with santitizers. TODO: Fix this problem and uncomment the test case below.
-# add_test(NAME moved-redirect-test-async
-#          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/moved-redirect-test.sh"
-#          "$<TARGET_FILE:clusterclient_async>"
-#          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+add_test(NAME moved-redirect-test-async
+         COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/moved-redirect-test.sh"
+         "$<TARGET_FILE:clusterclient_async>"
+         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
 add_test(NAME dbsize-to-all-nodes-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/dbsize-to-all-nodes-test.sh"
                  "$<TARGET_FILE:clusterclient_all_nodes>"


### PR DESCRIPTION
This PR fixes 3 async issues:
1. When a node is removed all registered command callbacks are called with a NULL response.
This can happen when a new cluster topology is fetched. During this command callback handling
a NULL response might trigger the use of the nodes dict that is currently under deletion, which triggers a crash.
By making sure the nodes dict is replaced before we delete the old one a crash is avoided.
2. Return an error instead of asserting when a user attempts to send a command while a connection is disconnecting.
3. Correcting possible memory issue during MOVED handling.

Fixes #105 
