### PR TITLE
Updates to resolve build issues on Windows platforms

### DIFF
--- a/hiutil.c
+++ b/hiutil.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <sys/types.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
@@ -51,7 +51,7 @@
 #include "hiutil.h"
 #include "win32.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 int hi_set_blocking(int sd) {
     int flags;
 
@@ -345,7 +345,7 @@ int _scnprintf(char *buf, size_t size, const char *fmt, ...) {
     return n;
 }
 
-#ifndef WIN32
+#ifndef _WIN32
 /*
  * Send n bytes on a blocking descriptor
  */
@@ -410,7 +410,7 @@ ssize_t _hi_recvn(int sd, void *vptr, size_t n) {
  */
 int64_t hi_usec_now(void) {
     int64_t usec;
-#ifdef _MSC_VER
+#ifdef _WIN32
     LARGE_INTEGER counter, frequency;
 
     if (!QueryPerformanceCounter(&counter) ||

--- a/hiutil.h
+++ b/hiutil.h
@@ -87,7 +87,7 @@ typedef int rstatus_t; /* return type */
 
 #define uint_len(_n) _uint_len((uint32_t)_n)
 
-#ifndef WIN32
+#ifndef _WIN32
 int hi_set_blocking(int sd);
 int hi_set_nonblocking(int sd);
 int hi_set_reuseaddr(int sd);
@@ -107,7 +107,7 @@ int hi_valid_port(int n);
 
 int _uint_len(uint32_t num);
 
-#ifndef WIN32
+#ifndef _WIN32
 /*
  * Wrappers to send or receive n byte message on a blocking
  * socket descriptor.
@@ -129,7 +129,7 @@ int _uint_len(uint32_t num);
 
 #define hi_writev(_d, _b, _n) writev(_d, _b, (int)(_n))
 
-#ifndef WIN32
+#ifndef _WIN32
 ssize_t _hi_sendn(int sd, const void *vptr, size_t n);
 ssize_t _hi_recvn(int sd, void *vptr, size_t n);
 #endif

--- a/win32.h
+++ b/win32.h
@@ -45,6 +45,9 @@
 #endif /* _MSC_VER */
 
 #ifdef _WIN32
+
+#include <profileapi.h> /* for QueryPerformance APIs */
+
 #define strerror_r(errno, buf, len) strerror_s(buf, len, errno)
 #endif /* _WIN32 */
 


### PR DESCRIPTION
When using MinGW64 compilers these minor changes are needed to resolve build warnings and errors.