### PR TITLE
Build using MinGW64 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,21 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
           ninja -v
+
+  windows-mingw64:
+    name: Windows (MinGW64)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up MinGW
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x64
+      - name: Prepare
+        run: |
+          choco install -y ninja
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -G Ninja -DDISABLE_TESTS=ON
+          cmake --build .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,14 @@ jobs:
         with:
           platform: x64
       - name: Prepare
+        env:
+          VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic
+          VCPKG_DEFAULT_HOST_TRIPLET: x64-mingw-dynamic
         run: |
           choco install -y ninja
+          vcpkg install libevent
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DDISABLE_TESTS=ON
+          cmake .. -G Ninja -DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
           cmake --build .

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,14 +44,14 @@ find_library(LIBEVENT_LIBRARY event HINTS /usr/lib/x86_64-linux-gnu)
 find_path(LIBEVENT_INCLUDES event2/event.h)
 include_directories(${LIBEVENT_INCLUDES})
 
-if(MSVC)
+if(MSVC OR MINGW)
   find_library(LIBEVENT_LIBRARY Libevent)
 else()
   add_compile_options(-Wall -Wextra -pedantic -Werror)
+  # Debug mode for tests
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
 endif()
 
-# Debug mode for tests
-set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
 # Make sure ctest gives the output when tests fail
 list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 


### PR DESCRIPTION
~~Note:
Tests are not built due to some version mismatch in libevent.
`vcpkg install --triplet x64-windows libevent` that works for the windows job seems to give different libevent headers when building with MinGW.~~