### PR TITLE
No assert in the callback handling when a node is already removed

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -3852,7 +3852,7 @@ static void redisClusterAsyncRetryCallback(redisAsyncContext *ac, void *r,
     int error_type;
     cluster_node *node;
     struct cmd *command;
-    int64_t now, next;
+    int64_t now;
 
     if (cad == NULL) {
         goto error;
@@ -3926,7 +3926,7 @@ static void redisClusterAsyncRetryCallback(redisAsyncContext *ac, void *r,
                 hi_atoi(cluster_timeout_str, cluster_timeout_str_len);
             hi_free(cluster_timeout_str);
 
-            if (cluster_timeout <= 0) {
+            if (cluster_timeout < 0) {
                 __redisClusterAsyncSetError(
                     acc, REDIS_ERR_OTHER,
                     "cluster_timeout_str convert to integer error");
@@ -3940,9 +3940,7 @@ static void redisClusterAsyncRetryCallback(redisAsyncContext *ac, void *r,
                 goto done;
             }
 
-            next = now + (cluster_timeout * 1000LL);
-
-            cc->update_route_time = next;
+            cc->update_route_time = now + (cluster_timeout * 1000LL);
         }
 
         goto done;

--- a/hircluster.c
+++ b/hircluster.c
@@ -3882,10 +3882,11 @@ static void redisClusterAsyncRetryCallback(redisAsyncContext *ac, void *r,
         // If you have a better idea, please contact with me. Thank you.
         // My email: diguo58@gmail.com
 
-        node = (cluster_node *)(ac->data);
-        ASSERT(node != NULL);
-
         __redisClusterAsyncSetError(acc, ac->err, ac->errstr);
+
+        node = (cluster_node *)ac->data;
+        if (node == NULL)
+            goto done; /* Node already removed from topology */
 
         if (cc->update_route_time != 0) {
             now = hi_usec_now();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,8 @@ add_executable(clusterclient_async clusterclient_async.c)
 target_link_libraries(clusterclient_async hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_executable(clusterclient_reconnect_async clusterclient_reconnect_async.c)
 target_link_libraries(clusterclient_reconnect_async hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
+add_executable(clusterclient_async_sequence clusterclient_async_sequence.c)
+target_link_libraries(clusterclient_async_sequence hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
 add_test(NAME set-get-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/set-get-test.sh"
                  "$<TARGET_FILE:clusterclient>"
@@ -177,3 +179,7 @@ add_test(NAME reconnect-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/reconnect-test.sh"
                 "$<TARGET_FILE:clusterclient_reconnect_async>"
                 WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+add_test(NAME timeout-handling-test
+         COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/timeout-handling-test.sh"
+                 "$<TARGET_FILE:clusterclient_async_sequence>"
+         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")

--- a/tests/clusterclient_async_sequence.c
+++ b/tests/clusterclient_async_sequence.c
@@ -1,0 +1,132 @@
+/*
+ * This program connects to a Redis node and then reads commands from stdin, such
+ * as "SET foo bar", one per line and prints the results to stdout.
+ *
+ * The behaviour is similar to that of clusterclient_async.c, but it sends the
+ * next command after receiving a reply from the previous command.
+ * It is still possible to send multiple commands at once like in
+ # clusterclient_async.c using following action commands:
+ #
+ # !async - Send multiple commands and then wait for their responses.
+ #          Will send all following commands until EOF or the command `!sync`
+ #
+ # !sync  - Send a single command and wait for its response before sending next
+ #          command. This is the default behaviour.
+ *
+ * An example input of first sending 2 commands and waiting for their responses,
+ * before sending a single command and waiting for its response:
+ *
+ * !async
+ * SET dual-1 command
+ * SET dual-2 command
+ * !sync
+ * SET single command
+ *
+ */
+
+#include "adapters/libevent.h"
+#include "hircluster.h"
+#include "test_utils.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int num_running = 0;
+
+void sendNextCommand(int, short, void *);
+
+void replyCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
+    UNUSED(privdata);
+    redisReply *reply = (redisReply *)r;
+
+    if (reply == NULL) {
+        if (acc->err) {
+            printf("error: %s\n", acc->errstr);
+        } else {
+            printf("unknown error\n");
+        }
+    } else {
+        printf("%s\n", reply->str);
+    }
+
+    if (--num_running == 0) {
+        /* Schedule a read from stdin and send next command */
+        event_base_once(acc->adapter, -1, EV_TIMEOUT, sendNextCommand, acc,
+                        NULL);
+    }
+}
+
+void sendNextCommand(int fd, short kind, void *arg) {
+    UNUSED(fd);
+    UNUSED(kind);
+    redisClusterAsyncContext *acc = arg;
+    int async = 0;
+
+    char cmd[256];
+    while (fgets(cmd, 256, stdin)) {
+        size_t len = strlen(cmd);
+        if (cmd[len - 1] == '\n') /* Chop trailing line break */
+            cmd[len - 1] = '\0';
+
+        if (cmd[0] == '\0') /* Skip empty lines */
+            continue;
+        if (cmd[0] == '#') /* Skip comments */
+            continue;
+        if (cmd[0] == '!') {
+            if (strcmp(cmd, "!async") == 0) /* Enable async send */
+                async = 1;
+            if (strcmp(cmd, "!sync") == 0) { /* Disable async send */
+                if (async)
+                    return; /* We are done sending commands */
+            }
+            continue; /* Skip line */
+        }
+
+        int status = redisClusterAsyncCommand(acc, replyCallback, cmd, cmd);
+        ASSERT_MSG(status == REDIS_OK, acc->errstr);
+        num_running++;
+
+        if (async)
+            continue; /* Send next command as well */
+
+        return;
+    }
+
+    /* Disconnect if nothing is left to read from stdin */
+    redisClusterAsyncDisconnect(acc);
+}
+
+int main(int argc, char **argv) {
+    if (argc <= 1) {
+        fprintf(stderr, "Usage: %s HOST:PORT\n", argv[0]);
+        exit(1);
+    }
+    const char *initnode = argv[1];
+    struct timeval timeout = {0, 500000};
+
+    redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+    assert(acc);
+    redisClusterSetOptionAddNodes(acc->cc, initnode);
+    redisClusterSetOptionRouteUseSlots(acc->cc);
+    redisClusterSetOptionTimeout(acc->cc, timeout);
+    redisClusterSetOptionMaxRetry(acc->cc, 1);
+    redisClusterConnect2(acc->cc);
+    if (acc->err) {
+        printf("Connect error: %s\n", acc->errstr);
+        exit(-1);
+    }
+
+    struct event_base *base = event_base_new();
+    int status = redisClusterLibeventAttach(acc, base);
+    assert(status == REDIS_OK);
+
+    /* Schedule a read from stdin and send next command */
+    event_base_once(acc->adapter, -1, EV_TIMEOUT, sendNextCommand, acc, NULL);
+
+    event_base_dispatch(base);
+
+    redisClusterAsyncFree(acc);
+    event_base_free(base);
+    return 0;
+}

--- a/tests/scripts/timeout-handling-test.sh
+++ b/tests/scripts/timeout-handling-test.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+#
+# Simulate a 2 node cluster.
+# - Node 1 will handle topology requests.
+# - Node 2 will have a problem which results in timed out requests.
+#
+# The client will first send a successful command, followed by
+# 4 pipelined commands which are all timed out.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient_async_sequence}
+testname=timeout-handling-test
+
+# Sync process just waiting for server to be ready to accept connection.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid1=$!
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid2=$!
+
+# Start simulated redis node #1
+timeout 5s ./simulated-redis.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
+# Inital topology
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 6000, ["127.0.0.1", 7401, "nodeid1"]],[6001, 16383, ["127.0.0.1", 7402, "nodeid2"]]]
+EXPECT CLOSE
+
+# Max retry triggers a fetch of config
+EXPECT CONNECT
+EXPECT ["PING"]
+SEND +PONG
+EXPECT ["config", "get", "cluster-node-timeout"]
+SEND ["cluster-node-timeout", "0"]
+
+# Topology changed, nodeid2 is now gone
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid1"]]]
+EXPECT CLOSE
+
+EXPECT CLOSE
+EOF
+server1=$!
+
+# Start simulated redis node #2
+timeout 5s ./simulated-redis.pl -p 7402 -d --sigcont $syncpid2 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["SET", "foo", "initial"]
+SEND +OK
+
+# First timed out command triggers a fetch of config "cluster-node-timeout"
+EXPECT ["SET", "foo", "timeout1"]
+# Second timed out command triggers a new topology fetch
+EXPECT ["SET", "foo", "timeout2"]
+EXPECT ["SET", "foo", "timeout3"]
+EXPECT ["SET", "foo", "timeout4"]
+SLEEP 1
+EXPECT CLOSE
+EOF
+server2=$!
+
+# Wait until both nodes are ready to accept client connections
+wait $syncpid1 $syncpid2;
+
+# Run client
+timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+SET foo initial
+
+!async
+SET foo timeout1
+SET foo timeout2
+SET foo timeout3
+SET foo timeout4
+!sync
+
+EOF
+clientexit=$?
+
+# Wait for servers to exit
+wait $server1; server1exit=$?
+wait $server2; server2exit=$?
+
+# Check exit statuses
+if [ $server1exit -ne 0 ]; then
+    echo "Simulated server #1 exited with status $server1exit"
+    exit $server1exit
+fi
+if [ $server2exit -ne 0 ]; then
+    echo "Simulated server #2 exited with status $server2exit"
+    exit $server2exit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from clusterclient
+cmp "$testname.out" <<'EOF' || exit 99
+OK
+unknown error
+unknown error
+unknown error
+unknown error
+EOF
+
+# Clean up
+rm "$testname.out"


### PR DESCRIPTION
When a context is freed all its callbacks are called with a NULL response.
During the callback handling there is an attempt to update the topology after a number of attempts.
If the node is removed during this topology change the context's pointer to the node will be cleared.
The callbacks that follows needs to be able to finish, i.e not asserting.

Added a testcase that can trigger the issue.
Since the [Redis config `cluster-node-timeout`](https://github.com/redis/redis/blob/ce4ebe6ba858bd6be7cabdc830f5ef30d6fcd37a/src/config.c#L3118) allows a 0 value this is also accepted (and used in the testcase).

Fixes #111 