### PR TITLE
Lift hiredis to v1.1.0 in CI and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,15 @@ jobs:
     steps:
     - name: Prepare
       run: sudo apt install libevent-dev libuv1-dev libev-dev libglib2.0-dev ${{ matrix.compiler }}
-    - name: Setup cmake
-      # Temporary disabled due to actions-setup-cmake/issues/21
-      # uses: jwlawson/actions-setup-cmake@v1.6
-      # with:
-      #   cmake-version: ${{ matrix.cmake-version }}
+    - name: Install hiredis
       run: |
-        wget https://cmake.org/files/v${{ matrix.cmake-version }}/cmake-${{ matrix.cmake-version }}.0-Linux-x86_64.sh -O /tmp/cmake.sh
-        sudo sh /tmp/cmake.sh --prefix=/usr/local/ --exclude-subdir
-        # Make sure we use correct version
-        cmake --version | grep -c ${{ matrix.cmake-version }}.0
+        curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.1.0.tar.gz | tar -xz
+        cmake -S hiredis-1.1.0 -B hiredis-build -DENABLE_SSL=ON
+        sudo make -C hiredis-build install
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v1
+      with:
+        cmake-version: ${{ matrix.cmake-version }}
     - uses: actions/checkout@v3
     - name: Create build folder
       run: cmake -E make_directory build
@@ -76,7 +75,7 @@ jobs:
       env:
         CC: ${{ matrix.compiler }}
       working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DDOWNLOAD_HIREDIS=OFF -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
     - name: Build
       shell: bash
       working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if(DOWNLOAD_HIREDIS)
   include(FetchContent)
   FetchContent_Declare(hiredis
     GIT_REPOSITORY https://github.com/redis/hiredis
-    GIT_TAG        v1.0.0
+    GIT_TAG        v1.1.0
     SOURCE_DIR     "${CMAKE_CURRENT_BINARY_DIR}/_deps/hiredis"
   )
 

--- a/tests/scripts/timeout-handling-test.sh
+++ b/tests/scripts/timeout-handling-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Simulate a 2 node cluster.
 # - Node 1 will handle topology requests.
@@ -95,14 +95,22 @@ if [ $clientexit -ne 0 ]; then
     exit $clientexit
 fi
 
-# Check the output from clusterclient
-cmp "$testname.out" <<'EOF' || exit 99
-OK
+# Check the output from clusterclient, which depends on the hiredis version used.
+# hiredis v1.1.0
+expected1="OK
+error: Timeout
+error: Timeout
+error: Timeout
+error: Timeout"
+
+# hiredis < v1.1.0
+expected2="OK
 unknown error
 unknown error
 unknown error
-unknown error
-EOF
+unknown error"
+
+cmp "$testname.out" <(echo "$expected1") || cmp "$testname.out" <(echo "$expected2") || exit 99
 
 # Clean up
 rm "$testname.out"


### PR DESCRIPTION
Installing hiredis as an own step in CI to avoid issues with CMake < v1.20 and its FetchContent functionality.