### PR TITLE
Fix crash when using "CLUSTER NODES"

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -1363,6 +1363,11 @@ static int cluster_update_route_by_addr(redisClusterContext *cc, const char *ip,
         }
     }
 
+    if (hiarray_n(slots) == 0) {
+        __redisClusterSetError(cc, REDIS_ERR_OTHER, "No slot information");
+        goto error; // Cluster topology is not yet known
+    }
+
     hiarray_sort(slots, cluster_slot_start_cmp);
     for (j = 0; j < hiarray_n(slots); j++) {
         slot_elem = hiarray_get(slots, j);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,3 +183,7 @@ add_test(NAME timeout-handling-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/timeout-handling-test.sh"
                  "$<TARGET_FILE:clusterclient_async_sequence>"
          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+add_test(NAME connect-error-using-cluster-nodes-test
+         COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/connect-error-using-cluster-nodes-test.sh"
+                 "$<TARGET_FILE:clusterclient_async>"
+         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
 
     if (redisClusterConnect2(acc->cc) != REDIS_OK) {
         printf("Connect error: %s\n", acc->cc->errstr);
-        exit(1);
+        exit(2);
     }
 
     int status;

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -69,17 +69,16 @@ int main(int argc, char **argv) {
 
     int optind;
     for (optind = 1; optind < argc && argv[optind][0] == '-'; optind++) {
-        if (strcmp(argv[optind], "-n") == 0) {
-            use_cluster_slots = 0; // Get topology via CLUSTER NODES
+        if (strcmp(argv[optind], "--use-cluster-nodes") == 0) {
+            use_cluster_slots = 0; // Use the default CLUSTER NODES instead
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[optind]);
         }
     }
 
     if (optind >= argc) {
-        fprintf(stderr, "Usage: clusterclient_async [-n] HOST:PORT\n");
-        fprintf(stderr, "Options:\n");
-        fprintf(stderr, " -n  Get cluster topology using CLUSTER NODES\n");
+        fprintf(stderr,
+                "Usage: clusterclient_async [--use-cluster-nodes] HOST:PORT\n");
         exit(1);
     }
     const char *initnode = argv[optind];

--- a/tests/scripts/connect-error-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-error-using-cluster-nodes-test.sh
@@ -44,7 +44,7 @@ if [ $serverexit -ne 0 ]; then
 fi
 
 # Check exit status on client, which SHOULD fail.
-if [ $clientexit -ne 1 ]; then
+if [ $clientexit -ne 2 ]; then
     echo "$clientprog exited with status $clientexit"
     exit $clientexit
 fi

--- a/tests/scripts/connect-error-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-error-using-cluster-nodes-test.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Connect to a Redis node which have no knowledge of a cluster.
+#
+# The client is configured to use the CLUSTER NODES command,
+# which will receive a reply without slot information or other nodes.
+# This kind of reply is returned from a node configured as a cluster node,
+# but has not yet been included in a cluster.
+#
+# The client will return an error and error string.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient_async}
+testname=connect-error-using-cluster-nodes-test
+
+# Sync process just waiting for server to be ready to accept connection.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid=$!
+
+# Start simulated server
+timeout 5s ./simulated-redis.pl -p 7400 -d --sigcont $syncpid <<'EOF' &
+EXPECT CONNECT
+EXPECT ["CLUSTER", "NODES"]
+SEND "653876bce37106406581ddc05d8629357a223a7e :30001@40001 myself,master - 0 0 0 connected\n"
+EXPECT CLOSE
+EOF
+server=$!
+
+# Wait until server is ready to accept client connection
+wait $syncpid;
+
+# Run client and use CLUSTER NODES to get topology (-n)
+timeout 3s "$clientprog" -n 127.0.0.1:7400 > "$testname.out"
+clientexit=$?
+
+# Wait for server to exit
+wait $server; serverexit=$?
+
+# Check exit status on server.
+if [ $serverexit -ne 0 ]; then
+    echo "Simulated server exited with status $serverexit"
+    exit $serverexit
+fi
+
+# Check exit status on client, which SHOULD fail.
+if [ $clientexit -ne 1 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from clusterclient
+printf 'Connect error: No slot information\n' | cmp "$testname.out" - || exit 99
+
+# Clean up
+rm "$testname.out"

--- a/tests/scripts/connect-error-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-error-using-cluster-nodes-test.sh
@@ -30,8 +30,8 @@ server=$!
 # Wait until server is ready to accept client connection
 wait $syncpid;
 
-# Run client and use CLUSTER NODES to get topology (-n)
-timeout 3s "$clientprog" -n 127.0.0.1:7400 > "$testname.out"
+# Run client and use CLUSTER NODES to get topology
+timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out"
 clientexit=$?
 
 # Wait for server to exit


### PR DESCRIPTION
When fetching the cluster topology using the default command `CLUSTER NODES` from a node without any knowledge of the cluster, i.e. no slot information, there is an assert in the `hiarray_sort` function.
Lets return an error and error-string so that the next known node can be queried instead.