### PR TITLE
Handle multiple ASK redirect command responses

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -2261,6 +2261,7 @@ static cluster_node *node_get_by_ask_error_reply(redisClusterContext *cc,
         return NULL;
     }
 
+    /* Expecting ["ASK", "<slot>", "<endpoint>:<port>"] */
     part = sdssplitlen(reply->str, reply->len, " ", 1, &part_len);
     if (part == NULL) {
         goto oom;
@@ -2279,7 +2280,7 @@ static cluster_node *node_get_by_ask_error_reply(redisClusterContext *cc,
                 if (node == NULL) {
                     goto oom;
                 }
-                node->addr = part[1];
+                node->addr = part[2];
                 node->host = ip_port[0];
                 node->port = hi_atoi(ip_port[1], sdslen(ip_port[1]));
                 node->role = REDIS_ROLE_MASTER;
@@ -2295,7 +2296,7 @@ static cluster_node *node_get_by_ask_error_reply(redisClusterContext *cc,
                     goto oom;
                 }
 
-                part[1] = NULL;
+                part[2] = NULL; /* Memory now handled by cluster_node in dict */
                 ip_port[0] = NULL;
             } else {
                 node = de->val;

--- a/tests/scripts/ask-redirect-test.sh
+++ b/tests/scripts/ask-redirect-test.sh
@@ -20,6 +20,7 @@ EXPECT CLOSE
 EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 127.0.0.1:7402
+# A second redirect is needed to test reuse of the new cluster_node
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 127.0.0.1:7402
 EXPECT CLOSE


### PR DESCRIPTION
Use correct part of the ASK response string as key when
adding the new cluster node to the internal nodes dict.

The new node can now be found during handling of ASK responses
instead of getting an erroneous `Out of memory` error.