### PR TITLE
Remove unused cluster_slots array 

### DIFF
--- a/hircluster.h
+++ b/hircluster.h
@@ -117,7 +117,6 @@ typedef struct redisClusterContext {
     char *password;                  /* Authentication password */
 
     struct dict *nodes;     /* Known cluster_nodes*/
-    struct hiarray *slots;  /* Sorted array of cluster_slots */
     uint64_t route_version; /* Increased when the node lookup table changes */
     cluster_node **table;   /* cluster_node lookup table */
 

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -135,13 +135,13 @@ void test_alloc_failure_handling() {
 
     // Connect
     {
-        for (int i = 0; i < 130; ++i) {
+        for (int i = 0; i < 128; ++i) {
             prepare_allocation_test(cc, i);
             result = redisClusterConnect2(cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(cc, 130);
+        prepare_allocation_test(cc, 128);
         result = redisClusterConnect2(cc);
         assert(result == REDIS_OK);
     }
@@ -417,13 +417,13 @@ void test_alloc_failure_handling_async() {
 
     // Connect
     {
-        for (int i = 0; i < 128; ++i) {
+        for (int i = 0; i < 126; ++i) {
             prepare_allocation_test(acc->cc, i);
             result = redisClusterConnect2(acc->cc);
             assert(result == REDIS_ERR);
         }
 
-        prepare_allocation_test(acc->cc, 128);
+        prepare_allocation_test(acc->cc, 126);
         result = redisClusterConnect2(acc->cc);
         assert(result == REDIS_OK);
     }


### PR DESCRIPTION
`cc->slots` contains a sorted array of slot-ranges, but is not used internally nor provided via the public interface.
The same information can be extracted via the nodes dict  `cc->nodes`.
This PR removes the array.

The move of the slot-range check is covered by the existing test `connect-error-using-cluster-nodes-test.sh`