### PR TITLE
Update the MinGW setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,18 +141,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up MinGW
-        uses: egor-tensin/setup-mingw@v2
+        uses: msys2/setup-msys2@v2
         with:
-          platform: x64
-      - name: Prepare
-        env:
-          VCPKG_DEFAULT_TRIPLET: x64-mingw-dynamic
-          VCPKG_DEFAULT_HOST_TRIPLET: x64-mingw-dynamic
-        run: |
-          choco install -y ninja
-          vcpkg install libevent
+          msystem: mingw64
+          install: |
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-libevent
       - name: Build
+        shell: msys2 {0}
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DVCPKG_TARGET_TRIPLET=x64-mingw-dynamic -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+          cmake .. -G Ninja
           cmake --build .


### PR DESCRIPTION
Use [setup-msys2](https://github.com/msys2/setup-msys2) to setup the MinGW64 environment in the CI job.
It is well maintained and has built-in cache support, which improves the setup time in the CI job from about `5m` to `1m`.

This fixes the intermittent build problems caused by the previous used `egor-tensin/setup-mingw`.