### PR TITLE
Give build error message when using old CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,11 @@ set_target_properties(hiredis_cluster
     VERSION "${HIREDIS_CLUSTER_SONAME}")
 
 if(DOWNLOAD_HIREDIS)
+  if(${CMAKE_VERSION} VERSION_LESS "3.20")
+    message(FATAL_ERROR
+      "Downloading of the dependency 'hiredis' requires CMake >= v3.20.\n"
+      "Upgrade CMake or manually install 'hiredis' and use -DDOWNLOAD_HIREDIS=OFF")
+  endif()
   message("Downloading dependency 'hiredis'..")
 
   include(FetchContent)


### PR DESCRIPTION
`hiredis-cluster` can download its dependency `hiredis` automatically.
The downloading of hiredis `v1.1.0` requires CMake v3.20 or later, which includes a correction in its FetchContent functionality.

Give some hints how to proceeded when using a older CMake instead of just failing.
This was mentioned in #121.