### PR TITLE
Find hiredis libraries when its CMake packages are not found during builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       run: |
         examples/using_cmake_externalproject/build.sh
         examples/using_cmake_separate/build.sh
+        examples/using_cmake_and_make_mixed/build.sh
         examples/using_make/build.sh
 
   macos:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,15 @@ else()
   message("Expecting to find dependencies in path..")
 endif()
 
-find_package(hiredis REQUIRED)
+find_package(hiredis QUIET)
+if(NOT hiredis_FOUND)
+  message("CMake package for 'hiredis' not found, searching for the library..")
+  find_library(HIREDIS_LIB hiredis REQUIRED)
+  find_path(HIREDIS_INCLUDES hiredis/hiredis.h)
+  add_library(hiredis UNKNOWN IMPORTED GLOBAL)
+  set_target_properties(hiredis PROPERTIES IMPORTED_LOCATION ${HIREDIS_LIB})
+  set_target_properties(hiredis PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${HIREDIS_INCLUDES})
+endif()
 
 if(NOT TARGET hiredis::hiredis)
   # Add target to support older hiredis releases
@@ -136,7 +144,15 @@ else()
 endif()
 
 if(ENABLE_SSL)
-  find_package(hiredis_ssl REQUIRED)
+  find_package(hiredis_ssl QUIET)
+  if(NOT hiredis_ssl_FOUND)
+    message("CMake package for 'hiredis_ssl' not found, searching for the library..")
+    find_library(HIREDIS_SSL_LIB hiredis_ssl REQUIRED)
+    find_path(HIREDIS_SSL_INCLUDES hiredis/hiredis_ssl.h)
+    add_library(hiredis_ssl UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(hiredis_ssl PROPERTIES IMPORTED_LOCATION ${HIREDIS_SSL_LIB})
+    set_target_properties(hiredis_ssl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${HIREDIS_SSL_INCLUDES})
+  endif()
 
   if(NOT TARGET hiredis::hiredis_ssl)
     # Add target to support older hiredis releases

--- a/examples/using_cmake_and_make_mixed/build.sh
+++ b/examples/using_cmake_and_make_mixed/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+# This script builds and installs hiredis using GNU Make and hiredis-cluster using CMake.
+# The shared library variants are used when building the examples.
+
+script_dir=$(realpath "${0%/*}")
+repo_dir=$(git rev-parse --show-toplevel)
+
+# Download hiredis
+hiredis_version=1.1.0
+curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
+
+# Build and install downloaded hiredis using GNU Make
+make -C ${script_dir}/hiredis-${hiredis_version} \
+     USE_SSL=1 \
+     DESTDIR=${script_dir}/install \
+     all install
+
+
+# Build and install hiredis-cluster from the repo using CMake.
+mkdir -p ${script_dir}/hiredis_cluster_build
+cd ${script_dir}/hiredis_cluster_build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DDISABLE_TESTS=ON -DENABLE_SSL=ON -DDOWNLOAD_HIREDIS=OFF \
+      -DCMAKE_PREFIX_PATH=${script_dir}/install/usr/local \
+      ${repo_dir}
+make DESTDIR=${script_dir}/install clean install
+
+
+# Build example binaries by providing shared libraries
+make -C ${repo_dir} CFLAGS="-I${script_dir}/install/usr/local/include" \
+     LDFLAGS="-lhiredis_cluster -lhiredis_cluster_ssl -lhiredis -lhiredis_ssl \
+              -L${script_dir}/install/usr/local/lib/ \
+              -Wl,-rpath=${script_dir}/install/usr/local/lib/" \
+     USE_SSL=1 \
+     clean examples


### PR DESCRIPTION
The CMake build attempts to find the installed CMake packages for `hiredis`,
which are only installed if `hiredis` was built and installed using CMake.

By adding an alternative search for the library files we now handle setups
where `hiredis` was installed using its regular makefile.

Added a build example for verification.