### PR TITLE
Use cached apt packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
 
     steps:
     - name: Prepare
-      run: sudo apt install libevent-dev libuv1-dev libev-dev libglib2.0-dev ${{ matrix.compiler }}
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libevent-dev libuv1-dev libev-dev libglib2.0-dev ${{ matrix.compiler }}
+        version: 1.0
     - name: Install hiredis
       run: |
         curl -L https://github.com/redis/hiredis/archive/refs/tags/v1.1.0.tar.gz | tar -xz

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -26,14 +26,16 @@ jobs:
         COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
 
     - name: Prepare
-      run: |
-        sudo apt-get install -y libevent-dev gcc cmake
-        mkdir build; cd build
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SSL=ON ..
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: libevent-dev cmake
+        version: 1.0
 
     - name: Build with Coverity
-      run: cov-build --dir cov-int make
-      working-directory: build
+      run: |
+        mkdir build; cd build
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SSL=ON ..
+        cov-build --dir cov-int make
 
     - name: Submit the result to Coverity
       run: |

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -16,7 +16,10 @@ jobs:
           - redis-version: 5.0.14
     steps:
       - name: Prepare
-        run: sudo apt install libevent-dev
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libevent-dev
+          version: 1.0
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
There are sometimes problems with accessing apt repositories from CI,
which results in failing CI runs.

By caching the packages using:
https://github.com/marketplace/actions/cache-apt-packages
we should get more stable (and faster) CI runs.