### PR TITLE
Fix builds when using Clang 15

### DIFF
--- a/command.c
+++ b/command.c
@@ -392,7 +392,7 @@ oom:
     r->result = CMD_PARSE_ENOMEM;
 }
 
-struct cmd *command_get() {
+struct cmd *command_get(void) {
     struct cmd *command;
     command = hi_malloc(sizeof(struct cmd));
     if (command == NULL) {

--- a/hircluster.c
+++ b/hircluster.c
@@ -3716,7 +3716,7 @@ actx_get_after_update_route_by_slot(redisClusterAsyncContext *acc,
     return ac;
 }
 
-redisClusterAsyncContext *redisClusterAsyncContextInit() {
+redisClusterAsyncContext *redisClusterAsyncContextInit(void) {
     redisClusterContext *cc;
     redisClusterAsyncContext *acc;
 

--- a/tests/ct_async.c
+++ b/tests/ct_async.c
@@ -32,7 +32,7 @@ void disconnectCallback(const redisAsyncContext *ac, int status) {
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
-int main() {
+int main(void) {
     redisClusterAsyncContext *acc =
         redisClusterAsyncConnect(CLUSTER_NODE, HIRCLUSTER_FLAG_NULL);
     assert(acc);

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -455,7 +455,7 @@ void test_multi(redisClusterContext *cc) {
     assert(r == NULL);
 }
 
-int main() {
+int main(void) {
     struct timeval timeout = {0, 500000};
 
     redisClusterContext *cc = redisClusterContextInit();

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -15,7 +15,7 @@
 
 // Connecting to a password protected cluster and
 // providing a correct password.
-void test_password_ok() {
+void test_password_ok(void) {
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
     redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
@@ -37,7 +37,7 @@ void test_password_ok() {
 
 // Connecting to a password protected cluster and
 // providing wrong password.
-void test_password_wrong() {
+void test_password_wrong(void) {
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
     redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
@@ -58,7 +58,7 @@ void test_password_wrong() {
 
 // Connecting to a password protected cluster and
 // not providing any password.
-void test_password_missing() {
+void test_password_missing(void) {
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
     redisClusterSetOptionAddNodes(cc, CLUSTER_NODE_WITH_PASSWORD);
@@ -76,7 +76,7 @@ void test_password_missing() {
 
 // Connect to a cluster and authenticate using username and password,
 // i.e. 'AUTH <username> <password>'
-void test_username_ok() {
+void test_username_ok(void) {
     if (redis_version_less_than(6, 0))
         return;
 
@@ -99,7 +99,7 @@ void test_username_ok() {
 }
 
 // Test of disabling the use of username after it was enabled.
-void test_username_disabled() {
+void test_username_disabled(void) {
     if (redis_version_less_than(6, 0))
         return;
 
@@ -135,7 +135,7 @@ void test_username_disabled() {
 }
 
 // Connect and handle two clusters simultaneously
-void test_multicluster() {
+void test_multicluster(void) {
     int ret;
     redisReply *reply;
 
@@ -184,7 +184,7 @@ void test_multicluster() {
 }
 
 /* Connect to a non-routable address which results in a connection timeout. */
-void test_connect_timeout() {
+void test_connect_timeout(void) {
     struct timeval timeout = {0, 200000};
 
     redisClusterContext *cc = redisClusterContextInit();
@@ -203,7 +203,7 @@ void test_connect_timeout() {
 }
 
 /* Connect using a pre-configured command timeout */
-void test_command_timeout() {
+void test_command_timeout(void) {
     struct timeval timeout = {0, 10000};
 
     redisClusterContext *cc = redisClusterContextInit();
@@ -238,7 +238,7 @@ void test_command_timeout() {
 }
 
 /* Connect and configure a command timeout while connected. */
-void test_command_timeout_set_while_connected() {
+void test_command_timeout_set_while_connected(void) {
     struct timeval timeout = {0, 10000};
 
     redisClusterContext *cc = redisClusterContextInit();
@@ -318,7 +318,7 @@ void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
 
 // Connecting to a password protected cluster using
 // the async API, providing correct password.
-void test_async_password_ok() {
+void test_async_password_ok(void) {
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
     assert(acc);
     redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
@@ -349,7 +349,7 @@ void test_async_password_ok() {
 
 // Connecting to a password protected cluster using
 // the async API, providing wrong password.
-void test_async_password_wrong() {
+void test_async_password_wrong(void) {
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
     assert(acc);
     redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
@@ -385,7 +385,7 @@ void test_async_password_wrong() {
 
 // Connecting to a password protected cluster using
 // the async API, not providing a password.
-void test_async_password_missing() {
+void test_async_password_missing(void) {
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
     assert(acc);
     redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
@@ -417,7 +417,7 @@ void test_async_password_missing() {
 }
 
 // Connect to a cluster and authenticate using username and password
-void test_async_username_ok() {
+void test_async_username_ok(void) {
     if (redis_version_less_than(6, 0))
         return;
 
@@ -463,7 +463,7 @@ void test_async_username_ok() {
 }
 
 // Connect and handle two clusters simultaneously using the async API
-void test_async_multicluster() {
+void test_async_multicluster(void) {
     int ret;
 
     redisClusterAsyncContext *acc1 = redisClusterAsyncContextInit();
@@ -529,7 +529,7 @@ void test_async_multicluster() {
 }
 
 /* Connect to a non-routable address which results in a connection timeout. */
-void test_async_connect_timeout() {
+void test_async_connect_timeout(void) {
     struct timeval timeout = {0, 200000};
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
@@ -554,7 +554,7 @@ void test_async_connect_timeout() {
 }
 
 /* Connect using a pre-configured command timeout */
-void test_async_command_timeout() {
+void test_async_command_timeout(void) {
     struct timeval timeout = {0, 10000};
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
@@ -587,7 +587,7 @@ void test_async_command_timeout() {
     event_base_free(base);
 }
 
-int main() {
+int main(void) {
 
     test_password_ok();
     test_password_wrong();

--- a/tests/ct_connection_ipv6.c
+++ b/tests/ct_connection_ipv6.c
@@ -9,7 +9,7 @@
 #define CLUSTER_NODE_IPV6 "::1:7200"
 
 // Successful connection an IPv6 cluster
-void test_successful_ipv6_connection() {
+void test_successful_ipv6_connection(void) {
 
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
@@ -40,7 +40,7 @@ void test_successful_ipv6_connection() {
     redisClusterFree(cc);
 }
 
-int main() {
+int main(void) {
 
     test_successful_ipv6_connection();
 

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -67,7 +67,7 @@ void prepare_allocation_test_async(redisClusterAsyncContext *acc,
 //      use gdb to find out which iteration that fails (print i)
 //      Update i in for-loop and the prepare_allocation_test(_, x) in
 //      the test section just after.
-void test_alloc_failure_handling() {
+void test_alloc_failure_handling(void) {
     int result;
     hiredisAllocFuncs ha = {
         .mallocFn = hi_malloc_fail,
@@ -367,7 +367,7 @@ void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
 // It will start by triggering an allocation fault, and the next iteration
 // will start with an successfull allocation and then a failing one,
 // next iteration 2 successful and one failing allocation, and so on..
-void test_alloc_failure_handling_async() {
+void test_alloc_failure_handling_async(void) {
     int result;
     hiredisAllocFuncs ha = {
         .mallocFn = hi_malloc_fail,
@@ -484,7 +484,7 @@ void test_alloc_failure_handling_async() {
     event_base_free(base);
 }
 
-int main() {
+int main(void) {
 
     test_alloc_failure_handling();
     test_alloc_failure_handling_async();

--- a/tests/ct_pipeline.c
+++ b/tests/ct_pipeline.c
@@ -11,7 +11,7 @@
 #define CLUSTER_NODE "127.0.0.1:7000"
 
 // Test of two pipelines using sync API
-void test_pipeline() {
+void test_pipeline(void) {
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
 
@@ -58,7 +58,7 @@ void test_pipeline() {
 }
 
 // Test of pipelines containing multi-node commands
-void test_pipeline_with_multinode_commands() {
+void test_pipeline_with_multinode_commands(void) {
     redisClusterContext *cc = redisClusterContextInit();
     assert(cc);
 
@@ -123,7 +123,7 @@ void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
 // In an asynchronous context, commands are automatically pipelined due to the
 // nature of an event loop. Therefore, unlike the synchronous API, there is only
 // a single way to send commands.
-void test_async_pipeline() {
+void test_async_pipeline(void) {
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
     assert(acc);
     redisClusterAsyncSetConnectCallback(acc, callbackExpectOk);
@@ -167,7 +167,7 @@ void test_async_pipeline() {
     event_base_free(base);
 }
 
-int main() {
+int main(void) {
 
     test_pipeline();
     test_pipeline_with_multinode_commands();

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -317,7 +317,7 @@ void commandCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
         redisClusterAsyncDisconnect(cc);
 }
 
-void test_async_to_single_node() {
+void test_async_to_single_node(void) {
     int status;
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
@@ -353,7 +353,7 @@ void test_async_to_single_node() {
     event_base_free(base);
 }
 
-void test_async_formatted_to_single_node() {
+void test_async_formatted_to_single_node(void) {
     int status;
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
@@ -390,7 +390,7 @@ void test_async_formatted_to_single_node() {
     event_base_free(base);
 }
 
-void test_async_to_all_nodes() {
+void test_async_to_all_nodes(void) {
     int status;
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
@@ -431,7 +431,7 @@ void test_async_to_all_nodes() {
     event_base_free(base);
 }
 
-void test_async_transaction() {
+void test_async_transaction(void) {
     int status;
 
     redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
@@ -479,7 +479,7 @@ void test_async_transaction() {
     event_base_free(base);
 }
 
-int main() {
+int main(void) {
     int status;
 
     redisClusterContext *cc = redisClusterContextInit();

--- a/tests/ut_parse_cmd.c
+++ b/tests/ut_parse_cmd.c
@@ -131,7 +131,7 @@ void test_redis_parse_cmd_xgroup_destroy_ok(void) {
     command_destroy(c);
 }
 
-int main() {
+int main(void) {
     test_redis_parse_error_nonresp();
     test_redis_parse_cmd_get();
     test_redis_parse_cmd_mset();


### PR DESCRIPTION
The diagnostics in Clang 15 is stricter and found a lot of:
```
[-Werror,-Wstrict-prototypes]
  function declaration without a prototype is deprecated
```