### PR TITLE
Rename type `cluster_node` to `redisClusterNode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ int redisClusterAppendCommand(redisClusterContext *cc, const char *format, ...);
 int redisClusterAppendCommandArgv(redisClusterContext *cc, int argc, const char **argv);
 
 /* Send a command to a specific cluster node */
-int redisClusterAppendCommandToNode(redisClusterContext *cc, cluster_node *node,
+int redisClusterAppendCommandToNode(redisClusterContext *cc, redisClusterNode *node,
                                     const char *format, ...);
 ```
 After calling either function one or more times, `redisClusterGetReply` can be used to receive the
@@ -331,11 +331,11 @@ int redisClusterAsyncCommand(redisClusterAsyncContext *acc,
                              redisClusterCallbackFn *fn,
                              void *privdata, const char *format, ...);
 int redisClusterAsyncCommandToNode(redisClusterAsyncContext *acc,
-                                   cluster_node *node,
+                                   redisClusterNode *node,
                                    redisClusterCallbackFn *fn, void *privdata,
                                    const char *format, ...);
 int redisClusterAsyncFormattedCommandToNode(redisClusterAsyncContext *acc,
-                                            cluster_node *node,
+                                            redisClusterNode *node,
                                             redisClusterCallbackFn *fn,
                                             void *privdata, char *cmd, int len);
 ```

--- a/hircluster.c
+++ b/hircluster.c
@@ -1993,7 +1993,7 @@ static redisClusterNode *node_get_by_table(redisClusterContext *cc,
 
 static redisClusterNode *node_get_which_connected(redisClusterContext *cc) {
     dictEntry *de;
-    struct redisClusterNode *node;
+    redisClusterNode *node;
     redisContext *c = NULL;
 
     if (cc == NULL || cc->nodes == NULL) {
@@ -3292,7 +3292,7 @@ int redisClusterAppendCommandArgv(redisClusterContext *cc, int argc,
 
 static int redisClusterSendAll(redisClusterContext *cc) {
     dictEntry *de;
-    struct redisClusterNode *node;
+    redisClusterNode *node;
     redisContext *c = NULL;
     int wdone = 0;
 
@@ -3327,7 +3327,7 @@ static int redisClusterSendAll(redisClusterContext *cc) {
 
 static int redisClusterClearAll(redisClusterContext *cc) {
     dictEntry *de;
-    struct redisClusterNode *node;
+    redisClusterNode *node;
     redisContext *c = NULL;
 
     if (cc == NULL) {
@@ -4277,7 +4277,7 @@ void redisClusterAsyncDisconnect(redisClusterAsyncContext *acc) {
     redisClusterContext *cc;
     redisAsyncContext *ac;
     dictEntry *de;
-    struct redisClusterNode *node;
+    redisClusterNode *node;
 
     if (acc == NULL) {
         return;

--- a/hircluster.c
+++ b/hircluster.c
@@ -243,7 +243,8 @@ static int cluster_reply_error_type(redisReply *reply) {
     return CLUSTER_NOT_ERR;
 }
 
-static redisClusterNode *cluster_node_create(void) {
+/* Create and initiate the cluster node structure */
+static redisClusterNode *createRedisClusterNode(void) {
     /* use calloc to guarantee all fields are zeroed */
     return hi_calloc(1, sizeof(redisClusterNode));
 }
@@ -460,7 +461,7 @@ static redisClusterNode *node_get_with_slots(redisClusterContext *cc,
         goto error;
     }
 
-    node = cluster_node_create();
+    node = createRedisClusterNode();
     if (node == NULL) {
         goto oom;
     }
@@ -519,7 +520,7 @@ static redisClusterNode *node_get_with_nodes(redisClusterContext *cc,
         return NULL;
     }
 
-    node = cluster_node_create();
+    node = createRedisClusterNode();
     if (node == NULL) {
         goto oom;
     }
@@ -1610,7 +1611,7 @@ int redisClusterSetOptionAddNode(redisClusterContext *cc, const char *addr) {
             goto error;
         }
 
-        node = cluster_node_create();
+        node = createRedisClusterNode();
         if (node == NULL) {
             goto oom;
         }
@@ -2209,7 +2210,7 @@ static redisClusterNode *node_get_by_ask_error_reply(redisClusterContext *cc,
         if (ip_port_len == 2) {
             de = dictFind(cc->nodes, part[2]);
             if (de == NULL) {
-                node = cluster_node_create();
+                node = createRedisClusterNode();
                 if (node == NULL) {
                     goto oom;
                 }

--- a/hircluster.h
+++ b/hircluster.h
@@ -245,8 +245,7 @@ void redisClusterReset(redisClusterContext *cc);
 
 /* Internal functions */
 int cluster_update_route(redisClusterContext *cc);
-redisContext *ctx_get_by_node(redisClusterContext *cc,
-                              struct redisClusterNode *node);
+redisContext *ctx_get_by_node(redisClusterContext *cc, redisClusterNode *node);
 struct dict *parse_cluster_nodes(redisClusterContext *cc, char *str,
                                  int str_len, int flags);
 struct dict *parse_cluster_slots(redisClusterContext *cc, redisReply *reply,

--- a/tests/clusterclient_all_nodes.c
+++ b/tests/clusterclient_all_nodes.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
         nodeIterator ni;
         initNodeIterator(&ni, cc);
 
-        cluster_node *node;
+        redisClusterNode *node;
         while ((node = nodeNext(&ni)) != NULL) {
 
             redisReply *reply;

--- a/tests/clusterclient_reconnect_async.c
+++ b/tests/clusterclient_reconnect_async.c
@@ -76,7 +76,7 @@ void sendNextCommand(int fd, short kind, void *arg) {
 
         dictEntry *de = dictNext(&di);
         assert(de);
-        cluster_node *node = dictGetEntryVal(de);
+        redisClusterNode *node = dictGetEntryVal(de);
         assert(node);
 
         // coverity[tainted_scalar]

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -216,7 +216,7 @@ void test_command_timeout(void) {
 
     nodeIterator ni;
     initNodeIterator(&ni, cc);
-    cluster_node *node = nodeNext(&ni);
+    redisClusterNode *node = nodeNext(&ni);
     assert(node);
 
     /* Simulate a command timeout */
@@ -250,7 +250,7 @@ void test_command_timeout_set_while_connected(void) {
 
     nodeIterator ni;
     initNodeIterator(&ni, cc);
-    cluster_node *node = nodeNext(&ni);
+    redisClusterNode *node = nodeNext(&ni);
     assert(node);
 
     redisReply *reply;
@@ -571,7 +571,7 @@ void test_async_command_timeout(void) {
 
     nodeIterator ni;
     initNodeIterator(&ni, acc->cc);
-    cluster_node *node = nodeNext(&ni);
+    redisClusterNode *node = nodeNext(&ni);
     assert(node);
 
     /* Simulate a command timeout and expect a timeout error */

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -188,7 +188,7 @@ void test_alloc_failure_handling(void) {
         redisReply *reply;
         const char *cmd = "SET key value";
 
-        cluster_node *node = redisClusterGetNodeByKey(cc, "key");
+        redisClusterNode *node = redisClusterGetNodeByKey(cc, "key");
         assert(node);
 
         // OOM failing commands
@@ -289,7 +289,7 @@ void test_alloc_failure_handling(void) {
         redisReply *reply;
         const char *cmd = "SET foo one";
 
-        cluster_node *node = redisClusterGetNodeByKey(cc, "foo");
+        redisClusterNode *node = redisClusterGetNodeByKey(cc, "foo");
         assert(node);
 
         // OOM failing appends

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -18,7 +18,7 @@ void test_command_to_single_node(redisClusterContext *cc) {
 
     dictEntry *de = dictNext(&di);
     assert(de);
-    cluster_node *node = dictGetEntryVal(de);
+    redisClusterNode *node = dictGetEntryVal(de);
     assert(node);
 
     reply = redisClusterCommandToNode(cc, node, "DBSIZE");
@@ -32,7 +32,7 @@ void test_command_to_all_nodes(redisClusterContext *cc) {
     nodeIterator ni;
     initNodeIterator(&ni, cc);
 
-    cluster_node *node;
+    redisClusterNode *node;
     while ((node = nodeNext(&ni)) != NULL) {
 
         redisReply *reply;
@@ -45,7 +45,7 @@ void test_command_to_all_nodes(redisClusterContext *cc) {
 
 void test_transaction(redisClusterContext *cc) {
 
-    cluster_node *node = redisClusterGetNodeByKey(cc, "foo");
+    redisClusterNode *node = redisClusterGetNodeByKey(cc, "foo");
     assert(node);
 
     redisReply *reply;
@@ -73,7 +73,7 @@ void test_streams(redisClusterContext *cc) {
     char *id;
 
     /* Get the node that handles given stream */
-    cluster_node *node = redisClusterGetNodeByKey(cc, "mystream");
+    redisClusterNode *node = redisClusterGetNodeByKey(cc, "mystream");
     assert(node);
 
     /* Preparation: remove old stream/key */
@@ -82,7 +82,7 @@ void test_streams(redisClusterContext *cc) {
     freeReplyObject(reply);
 
     /* Query wrong node */
-    cluster_node *wrongNode = redisClusterGetNodeByKey(cc, "otherstream");
+    redisClusterNode *wrongNode = redisClusterGetNodeByKey(cc, "otherstream");
     assert(node != wrongNode);
     reply = redisClusterCommandToNode(cc, wrongNode, "XLEN mystream");
     CHECK_REPLY_ERROR(cc, reply, "MOVED");
@@ -185,7 +185,7 @@ void test_pipeline_to_single_node(redisClusterContext *cc) {
 
     dictEntry *de = dictNext(&di);
     assert(de);
-    cluster_node *node = dictGetEntryVal(de);
+    redisClusterNode *node = dictGetEntryVal(de);
     assert(node);
 
     status = redisClusterAppendCommandToNode(cc, node, "DBSIZE");
@@ -203,7 +203,7 @@ void test_pipeline_to_all_nodes(redisClusterContext *cc) {
     nodeIterator ni;
     initNodeIterator(&ni, cc);
 
-    cluster_node *node;
+    redisClusterNode *node;
     while ((node = nodeNext(&ni)) != NULL) {
         int status = redisClusterAppendCommandToNode(cc, node, "DBSIZE");
         ASSERT_MSG(status == REDIS_OK, cc->errstr);
@@ -234,7 +234,7 @@ void test_pipeline_transaction(redisClusterContext *cc) {
     int status;
     redisReply *reply;
 
-    cluster_node *node = redisClusterGetNodeByKey(cc, "foo");
+    redisClusterNode *node = redisClusterGetNodeByKey(cc, "foo");
     assert(node);
 
     status = redisClusterAppendCommandToNode(cc, node, "MULTI");
@@ -339,7 +339,7 @@ void test_async_to_single_node(void) {
 
     dictEntry *de = dictNext(&di);
     assert(de);
-    cluster_node *node = dictGetEntryVal(de);
+    redisClusterNode *node = dictGetEntryVal(de);
     assert(node);
 
     ExpectedResult r1 = {.type = REDIS_REPLY_INTEGER, .disconnect = true};
@@ -375,7 +375,7 @@ void test_async_formatted_to_single_node(void) {
 
     dictEntry *de = dictNext(&di);
     assert(de);
-    cluster_node *node = dictGetEntryVal(de);
+    redisClusterNode *node = dictGetEntryVal(de);
     assert(node);
 
     ExpectedResult r1 = {.type = REDIS_REPLY_INTEGER, .disconnect = true};
@@ -412,7 +412,7 @@ void test_async_to_all_nodes(void) {
 
     ExpectedResult r1 = {.type = REDIS_REPLY_INTEGER};
 
-    cluster_node *node;
+    redisClusterNode *node;
     while ((node = nodeNext(&ni)) != NULL) {
 
         status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
@@ -448,7 +448,7 @@ void test_async_transaction(void) {
     status = redisClusterLibeventAttach(acc, base);
     assert(status == REDIS_OK);
 
-    cluster_node *node = redisClusterGetNodeByKey(acc->cc, "foo");
+    redisClusterNode *node = redisClusterGetNodeByKey(acc->cc, "foo");
     assert(node);
 
     ExpectedResult r1 = {.type = REDIS_REPLY_STATUS, .str = "OK"};

--- a/tests/scripts/ask-redirect-test.sh
+++ b/tests/scripts/ask-redirect-test.sh
@@ -20,7 +20,7 @@ EXPECT CLOSE
 EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 127.0.0.1:7402
-# A second redirect is needed to test reuse of the new cluster_node
+# A second redirect is needed to test reuse of the new cluster node
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 127.0.0.1:7402
 EXPECT CLOSE

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -11,7 +11,7 @@ static int redis_version_minor;
 #define REDIS_VERSION_FIELD "redis_version:"
 void load_redis_version(redisClusterContext *cc) {
     nodeIterator ni;
-    cluster_node *node;
+    redisClusterNode *node;
     char *eptr, *s, *e;
     redisReply *reply = NULL;
 


### PR DESCRIPTION
The new name uses a prefix which match other exported types from the library.
A `cluster_node` typedef is kept for backwards compatibility.

This includes changes of the types internal create and "deinit" functions,
and renaming them to:
- createRedisClusterNode()
- freeRedisClusterNode()

