### PR TITLE
Create and install a version file for the hiredis-cluster CMake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,14 @@ if(DOWNLOAD_HIREDIS)
       "Downloading of the dependency 'hiredis' requires CMake >= v3.20.\n"
       "Upgrade CMake or manually install 'hiredis' and use -DDOWNLOAD_HIREDIS=OFF")
   endif()
-  message("Downloading dependency 'hiredis'..")
+
+  set(HIREDIS_VERSION "1.1.0")
+  message("Downloading dependency: hiredis v${HIREDIS_VERSION}")
 
   include(FetchContent)
   FetchContent_Declare(hiredis
     GIT_REPOSITORY https://github.com/redis/hiredis
-    GIT_TAG        v1.1.0
+    GIT_TAG        "v${HIREDIS_VERSION}"
     SOURCE_DIR     "${CMAKE_CURRENT_BINARY_DIR}/_deps/hiredis"
   )
 
@@ -103,6 +105,7 @@ if(DOWNLOAD_HIREDIS)
   set(stub_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/pkg")
 
   file(WRITE "${stub_dir}/hiredis-config.cmake" "")
+  file(WRITE "${stub_dir}/hiredis-config-version.cmake" "set(PACKAGE_VERSION ${HIREDIS_VERSION})")
   set(hiredis_DIR ${stub_dir})
   # Set variables normally got from hiredis-config.cmake
   set(hiredis_LIBRARIES hiredis::hiredis)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,8 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(hiredis_cluster-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/hiredis_cluster-config.cmake
   INSTALL_DESTINATION ${CMAKE_CONF_INSTALL_DIR}
   PATH_VARS INCLUDE_INSTALL_DIR)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/hiredis_cluster-config-version.cmake
+  COMPATIBILITY SameMinorVersion)
 
 install(EXPORT hiredis_cluster-targets
   FILE hiredis_cluster-targets.cmake
@@ -228,6 +230,7 @@ install(EXPORT hiredis_cluster-targets
   DESTINATION ${CMAKE_CONF_INSTALL_DIR})
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hiredis_cluster-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/hiredis_cluster-config-version.cmake
   DESTINATION ${CMAKE_CONF_INSTALL_DIR})
 
 # Install target for hiredis_cluster_ssl


### PR DESCRIPTION
The version file for the CMake package enables users to ask for a specific version like:

` find_package(hiredis_cluster 0.10.1 REQUIRED)`    

which will find and accept all `0.10.x` versions but not `0.11.0`  (using [CMakePackageConfigHelpers](https://cmake.org/cmake/help/v3.11/module/CMakePackageConfigHelpers.html#generating-a-package-version-file)).

Additionally, this PR fixes a problem that CMake's `find_package()` don't understand which version that is used when the build downloads the hiredis package using `FetchContent`. This is fixed by creating a version file stub containing the package version.
This fixes a problem seen in PR #150, a testcase that should be run when using hiredis 1.0.1 will not run even when the build downloads hiredis 1.0.1.