### PR TITLE
Improve Make builds and its README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,17 @@ a static library, a similar limitation exists in the CMake files in hiredis v1.0
 
 The only option that exists in the Makefile is to enable SSL/TLS support via `USE_SSL=1`
 
+By default the hiredis library (and headers) installed on the system is used,
+but alternative installations can be used by defining the compiler flags
+`CFLAGS` and `LDFLAGS`.
+
 See [`examples/using_make/build.sh`](examples/using_make/build.sh) for an
-example build.
+example build using an alternative hiredis installation.
+
+Build failures like
+`hircluster_ssl.h:33:10: fatal error: hiredis/hiredis_ssl.h: No such file or directory`
+indicates that hiredis is not installed on the system, or that a given `CFLAGS` is wrong.
+Use the previous mentioned build example as reference.
 
 ### Running the tests
 

--- a/examples/using_make/build.sh
+++ b/examples/using_make/build.sh
@@ -20,7 +20,7 @@ make -C ${script_dir}/hiredis-${hiredis_version} \
 
 # Build and install hiredis-cluster from the repo using GNU Make
 make -C ${repo_dir} \
-     CFLAGS="-I${script_dir}/install/usr/local/include -D_XOPEN_SOURCE=600" \
+     CFLAGS="-I${script_dir}/install/usr/local/include" \
      LDFLAGS="-L${script_dir}/install/usr/local/lib" \
      USE_SSL=1 \
      DESTDIR=${script_dir}/install \

--- a/hircluster.c
+++ b/hircluster.c
@@ -30,6 +30,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#define _XOPEN_SOURCE 600
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>


### PR DESCRIPTION
- Define `_XOPEN_SOURCE` where needed instead of require it to be defined when building using Make.
- Update the `### Alternative build using Makefile directly` section in the README how `hiredis` is found.