### PR TITLE
Add connect callback for the sync API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,26 @@ if (cc != NULL && cc->err) {
 }
 ```
 
+There is a hook to get notified about connect and reconnect attempts.
+This is useful for applying socket options or access endpoint information for a connection to a particular node.
+The callback is registered using the following function:
+
+```c
+int redisClusterSetConnectCallback(redisClusterContext *cc,
+                                   void(fn)(const redisContext *c, int status));
+```
+
+The callback is called just after connect, before TLS handshake and Redis authentication.
+
+On successful connection, `status` is set to `REDIS_OK` and the redisContext
+(defined in hiredis.h) can be used, for example, to see which IP and port it's
+connected to or to set socket options directly on the file descriptor which can
+be accessed as `c->fd`.
+
+On failed connection attempt, this callback is called with `status` set to
+`REDIS_ERR`. The `err` field in the `redisContext` can be used to find out
+the cause of the error.
+
 ### Sending commands
 
 The function `redisClusterCommand` takes a format similar to printf.

--- a/hircluster.c
+++ b/hircluster.c
@@ -1908,10 +1908,6 @@ redisContext *ctx_get_by_node(redisClusterContext *cc, redisClusterNode *node) {
                 __redisClusterSetError(cc, c->err, c->errstr);
             }
 
-            if (cc->command_timeout && c->err == 0) {
-                redisSetTimeout(c, *cc->command_timeout);
-            }
-
             authenticate(cc, c); // err and errstr handled in function
         }
 

--- a/hircluster.c
+++ b/hircluster.c
@@ -1214,6 +1214,11 @@ static int cluster_update_route_by_addr(redisClusterContext *cc, const char *ip,
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         return REDIS_ERR;
     }
+
+    if (cc->on_connect) {
+        cc->on_connect(c, c->err ? REDIS_ERR : REDIS_OK);
+    }
+
     if (c->err) {
         __redisClusterSetError(cc, c->err, c->errstr);
         goto error;
@@ -1904,6 +1909,10 @@ redisContext *ctx_get_by_node(redisClusterContext *cc, redisClusterNode *node) {
         if (c->err) {
             redisReconnect(c);
 
+            if (cc->on_connect) {
+                cc->on_connect(c, c->err ? REDIS_ERR : REDIS_OK);
+            }
+
             if (cc->ssl && cc->ssl_init_fn(c, cc->ssl) != REDIS_OK) {
                 __redisClusterSetError(cc, c->err, c->errstr);
             }
@@ -1927,6 +1936,10 @@ redisContext *ctx_get_by_node(redisClusterContext *cc, redisClusterNode *node) {
     if (c == NULL) {
         __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
         return NULL;
+    }
+
+    if (cc->on_connect) {
+        cc->on_connect(c, c->err ? REDIS_ERR : REDIS_OK);
     }
 
     if (c->err) {
@@ -2773,6 +2786,16 @@ void redisClusterSetMaxRedirect(redisClusterContext *cc, int max_retry_count) {
     }
 
     cc->max_retry_count = max_retry_count;
+}
+
+int redisClusterSetConnectCallback(redisClusterContext *cc,
+                                   void(fn)(const redisContext *c,
+                                            int status)) {
+    if (cc->on_connect == NULL) {
+        cc->on_connect = fn;
+        return REDIS_OK;
+    }
+    return REDIS_ERR;
 }
 
 void *redisClusterFormattedCommand(redisClusterContext *cc, char *cmd,

--- a/hiredis_cluster.def
+++ b/hiredis_cluster.def
@@ -40,6 +40,7 @@
 	redisClusterGetNodeByKey
 	redisClusterGetReply
 	redisClusterReset
+	redisClusterSetConnectCallback
 	redisClusterSetMaxRedirect
 	redisClusterSetOptionAddNode
 	redisClusterSetOptionAddNodes


### PR DESCRIPTION
A connect callback is more flexible than providing connection options using the options API. The user can apply connection specific options (such as socket options) from the connect callback.

Additional small changes:

* Don't set command timeout after redisReconnect, because hiredis does this automatically. This saves a few syscalls at reconnect.
* Improve documentation of async connect in README. Some of this info seems to have been copied from hiredis, so it wasn't even correct for hiredis-cluster.