### PR TITLE
Enable IPv6 tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       env:
         CC: ${{ matrix.compiler }}
       working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DDOWNLOAD_HIREDIS=OFF -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DENABLE_IPV6_TESTS=ON -DDOWNLOAD_HIREDIS=OFF -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
     - name: Build
       shell: bash
       working-directory: build

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate makefiles
         shell: bash
         working-directory: build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DTEST_WITH_REDIS_VERSION=${{ matrix.redis-version }} ..
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release -DENABLE_IPV6_TESTS=ON -DTEST_WITH_REDIS_VERSION=${{ matrix.redis-version }} ..
 
       - name: Build
         shell: bash

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,9 +81,10 @@ set_tests_properties(ct_pipeline PROPERTIES LABELS "CT")
 
 add_executable(ct_connection_ipv6 ct_connection_ipv6.c)
 target_link_libraries(ct_connection_ipv6 hiredis_cluster ${SSL_LIBRARY} ${LIBEVENT_LIBRARY})
-if(ENABLE_IPV6_TESTS)
-  add_test(NAME ct_connection_ipv6 COMMAND "$<TARGET_FILE:ct_connection_ipv6>")
-  set_tests_properties(ct_connection_ipv6 PROPERTIES LABELS "CT")
+add_test(NAME ct_connection_ipv6 COMMAND "$<TARGET_FILE:ct_connection_ipv6>")
+set_tests_properties(ct_connection_ipv6 PROPERTIES LABELS "CT")
+if(NOT ENABLE_IPV6_TESTS)
+  set_tests_properties(ct_connection_ipv6 PROPERTIES DISABLED True)
 endif()
 
 add_executable(ct_out_of_memory_handling ct_out_of_memory_handling.c)

--- a/tests/scripts/redirect-with-ipv6-test.sh
+++ b/tests/scripts/redirect-with-ipv6-test.sh
@@ -31,10 +31,8 @@ EXPECT ["GET", "foo"]
 SEND -MOVED 12182 ::1:7402
 
 # Slotmap updated due to MOVED
-EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["::1", 7402, "nodeid2"]]]
-EXPECT CLOSE
 EXPECT CLOSE
 EOF
 server1=$!


### PR DESCRIPTION
Since Github runners seems to work fine with IPv6 lets enable these tests in CI.

Includes a fix for testcase `redirect-with-ipv6` due to the new redirect behavior
and a fix to show the testcase `ct_connection_ipv6` as disabled when IPv6 is disabled.