### PR TITLE
Add redisClusterAsyncConnect2()

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,11 @@ if (redisClusterAsyncConnect2(acc) != REDIS_OK) {
 }
 ```
 
+#### Events per cluster context
+
+Use [`redisClusterSetEventCallback`](#events-per-cluster-context) with `acc->cc`
+as the context to get notified when certain events occur.
+
 #### Events per connection
 
 Because the connections that will be created are non-blocking,

--- a/README.md
+++ b/README.md
@@ -354,19 +354,56 @@ for hiredis-cluster as well.
 
 ### Connecting
 
-The function `redisClusterAsyncConnect` can be used to
-establish a set of non-blocking connections to a Redis cluster.
-It returns a pointer to the newly created `redisClusterAsyncContext` struct.
-The `err` field should be checked after creation
-to see if there were errors creating the asynchronous cluster context.
+There are two alternative ways to initiate a cluster client which also determines
+how the client behaves during the initial connect.
+
+The first alternative is to use the function `redisClusterAsyncConnect`, which initially
+connects to the cluster in a blocking fashion and waits for the slot map before returning.
+Any command sent by the user thereafter will create a new non-blocking connection,
+unless a non-blocking connection already exists to the destination.
+The function returns a pointer to a newly created `redisClusterAsyncContext` struct.
+The `err` field should be checked after creation to make sure the slot map could be
+fetched correctly.
 
 ```c
 redisClusterAsyncContext *acc = redisClusterAsyncConnect("127.0.0.1:6379", HIRCLUSTER_FLAG_NULL);
 if (acc->err) {
+    // Handle error.
     printf("Error: %s\n", acc->errstr);
-    // handle error
+    exit(1);
 }
+
+// Attach an event engine. In this example we use libevent.
+struct event_base *base = event_base_new();
+redisClusterLibeventAttach(acc, base);
 ```
+
+The second alternative is to use `redisClusterAsyncContextInit` and `redisClusterAsyncConnect2`
+which avoids the initial blocking connect. This connection alternative requires an attached
+event engine when called but the initial connect and fetch of slot map is done in a
+non-blocking fashion.
+
+This means that commands sent directly after `redisClusterAsyncConnect2()` returns may fail
+because the initial slotmap has not yet been retrieved and then it is not yet known to which
+Redis node each command should be sent. You may use the [eventCallback](#events-per-cluster-context)
+to be notified when the slotmap is updated and the client is ready to accept commands.
+An crude example of using the eventCallback can be found in [this testcase](tests/ct_async.c).
+
+```c
+// Error handling omitted for brevity.
+redisClusterAsyncContext *acc = redisClusterAsyncContextInit();
+
+// Add a cluster node address for the initial connect.
+redisClusterSetOptionAddNodes(acc->cc, "127.0.0.1:6379");
+
+// Attach an event engine. In this example we use libevent.
+struct event_base *base = event_base_new();
+redisClusterLibeventAttach(acc, base);
+
+redisClusterAsyncConnect2(acc);
+```
+
+#### Events per connection
 
 Because the connections that will be created are non-blocking,
 the kernel is not able to instantly return if the specified

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ The callback is called with `event` set to one of the following values:
 
 * `HIRCLUSTER_EVENT_SLOTMAP_UPDATED` when the slot mapping has been updated;
 * `HIRCLUSTER_EVENT_READY` when the slot mapping has been fetched for the first
-  time and the client is ready to accept commands. Useful when starting the
+  time and the client is ready to accept commands. Useful when initiating the
   client with `redisClusterAsyncConnect2()` where a client is not immediately
   ready after a successful call.
 * `HIRCLUSTER_EVENT_FREE_CONTEXT` when the cluster context is being freed, so
@@ -384,7 +384,7 @@ slotmap update is done in a non-blocking fashion.
 
 This means that commands sent directly after `redisClusterAsyncConnect2` may fail
 because the initial slotmap has not yet been retrieved and the client dont know which
-Redis node to send the command to. You may use the [eventCallback](#events-per-cluster-context)
+cluster node to send the command to. You may use the [eventCallback](#events-per-cluster-context)
 to be notified when the slotmap is updated and the client is ready to accept commands.
 An crude example of using the eventCallback can be found in [this testcase](tests/ct_async.c).
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,6 @@ if (cc != NULL && cc->err) {
 #### Events per cluster context
 
 There is a hook to get notified when certain events occur.
-Currently, there is only one such event.
-It is that the slotmap has been updated.
 
 ```c
 int redisClusterSetEventCallback(redisClusterContext *cc,
@@ -224,7 +222,9 @@ The callback is called with `event` set to one of the following values:
 
 * `HIRCLUSTER_EVENT_SLOTMAP_UPDATED` when the slot mapping has been updated;
 * `HIRCLUSTER_EVENT_READY` when the slot mapping has been fetched for the first
-  time and the client is ready to accept commands;
+  time and the client is ready to accept commands. Useful when starting the
+  client with `redisClusterAsyncConnect2()` where a client is not immediately
+  ready after a successful call.
 * `HIRCLUSTER_EVENT_FREE_CONTEXT` when the cluster context is being freed, so
   that the user can free the event privdata.
 

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ The callback is called with `event` set to one of the following values:
 
 * `HIRCLUSTER_EVENT_SLOTMAP_UPDATED` when the slot mapping has been updated;
 * `HIRCLUSTER_EVENT_READY` when the slot mapping has been fetched for the first
-  time and the client is ready to accept commands. Useful when initiating the
+  time and the client is ready to accept commands, useful when initiating the
   client with `redisClusterAsyncConnect2()` where a client is not immediately
-  ready after a successful call.
+  ready after a successful call;
 * `HIRCLUSTER_EVENT_FREE_CONTEXT` when the cluster context is being freed, so
   that the user can free the event privdata.
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ event engine when `redisClusterAsyncConnect2` is called, but the connect and the
 slotmap update is done in a non-blocking fashion.
 
 This means that commands sent directly after `redisClusterAsyncConnect2` may fail
-because the initial slotmap has not yet been retrieved and the client dont know which
+because the initial slotmap has not yet been retrieved and the client doesn't know which
 cluster node to send the command to. You may use the [eventCallback](#events-per-cluster-context)
 to be notified when the slotmap is updated and the client is ready to accept commands.
 An crude example of using the eventCallback can be found in [this testcase](tests/ct_async.c).

--- a/hircluster.c
+++ b/hircluster.c
@@ -3754,6 +3754,14 @@ redisClusterAsyncContext *redisClusterAsyncConnect(const char *addrs,
     return acc;
 }
 
+int redisClusterAsyncConnect2(redisClusterAsyncContext *acc) {
+    /* An adapter to an async event library is required. */
+    if (acc->adapter == NULL) {
+        return REDIS_ERR;
+    }
+    return updateSlotMapAsync(acc, NULL /*any node*/);
+}
+
 int redisClusterAsyncSetConnectCallback(redisClusterAsyncContext *acc,
                                         redisConnectCallback *fn) {
     if (acc->onConnect == NULL) {

--- a/hircluster.h
+++ b/hircluster.h
@@ -294,6 +294,7 @@ int redisClusterAsyncSetDisconnectCallback(redisClusterAsyncContext *acc,
 
 redisClusterAsyncContext *redisClusterAsyncConnect(const char *addrs,
                                                    int flags);
+int redisClusterAsyncConnect2(redisClusterAsyncContext *acc);
 void redisClusterAsyncDisconnect(redisClusterAsyncContext *acc);
 
 /* Commands */

--- a/hircluster.h
+++ b/hircluster.h
@@ -289,8 +289,10 @@ int redisClusterAsyncSetConnectCallback(redisClusterAsyncContext *acc,
 int redisClusterAsyncSetDisconnectCallback(redisClusterAsyncContext *acc,
                                            redisDisconnectCallback *fn);
 
+/* Connect and update slotmap, will block until complete. */
 redisClusterAsyncContext *redisClusterAsyncConnect(const char *addrs,
                                                    int flags);
+/* Connect and update slotmap asynchronously using configured event engine. */
 int redisClusterAsyncConnect2(redisClusterAsyncContext *acc);
 void redisClusterAsyncDisconnect(redisClusterAsyncContext *acc);
 

--- a/hiredis_cluster.def
+++ b/hiredis_cluster.def
@@ -21,6 +21,7 @@
 	redisClusterAsyncCommandArgvToNode
 	redisClusterAsyncCommandToNode
 	redisClusterAsyncConnect
+	redisClusterAsyncConnect2
 	redisClusterAsyncDisconnect
 	redisClusterAsyncFormattedCommand
 	redisClusterAsyncFormattedCommandToNode


### PR DESCRIPTION
Adds a new public function `redisClusterAsyncConnect2()` which uses the attached event engine to get the initial slot map asynchronously compared to the legacy function `redisClusterAsyncConnect()` which is a blocking call.

Closes #123 