### PR TITLE
Prefix some API functions and types correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,23 @@ See the `adapters/` directory for bindings to *libevent* and a range of other ev
 
 ## Other details
 
+### Cluster node iterator
+
+A `redisClusterNodeIterator` can be used to iterate on all known master nodes in a cluster context.
+First it needs to be initiated using `redisClusterInitNodeIterator()` and then you can repeatedly
+call `redisClusterNodeNext()` to get the next node from the iterator.
+
+```c
+void redisClusterInitNodeIterator(redisClusterNodeIterator *iter,
+                                  redisClusterContext *cc);
+redisClusterNode *redisClusterNodeNext(redisClusterNodeIterator *iter);
+```
+
+The iterator will handle changes due to slotmap updates by restarting the iteration, but on the new
+set of master nodes. There is no bookkeeping for already iterated nodes when a restart is triggered,
+which means that a node can be iterated over more than once depending on when the slotmap update happened
+and the change of cluster nodes.
+
 ### Random number generator
 
 This library uses [random()](https://linux.die.net/man/3/random) while selecting

--- a/hircluster.c
+++ b/hircluster.c
@@ -1607,11 +1607,6 @@ redisClusterContext *redisClusterConnectWithTimeout(const char *addrs,
     return _redisClusterConnect(cc, addrs);
 }
 
-/* Deprecated function, replaced by redisClusterConnect() */
-redisClusterContext *redisClusterConnectNonBlock(const char *addrs, int flags) {
-    return redisClusterConnect(addrs, flags);
-}
-
 int redisClusterSetOptionAddNode(redisClusterContext *cc, const char *addr) {
     dictEntry *node_entry;
     redisClusterNode *node = NULL;
@@ -4405,7 +4400,8 @@ void redisClusterAsyncFree(redisClusterAsyncContext *acc) {
 }
 
 /* Initiate an iterator for iterating over current cluster nodes */
-void initNodeIterator(nodeIterator *iter, redisClusterContext *cc) {
+void redisClusterInitNodeIterator(redisClusterNodeIterator *iter,
+                                  redisClusterContext *cc) {
     iter->cc = cc;
     iter->route_version = cc->route_version;
     dictInitIterator(&iter->di, cc->nodes);
@@ -4415,7 +4411,7 @@ void initNodeIterator(nodeIterator *iter, redisClusterContext *cc) {
 /* Get next node from the iterator
  * The iterator will restart if the routing table is updated
  * before all nodes have been iterated. */
-redisClusterNode *nodeNext(nodeIterator *iter) {
+redisClusterNode *redisClusterNodeNext(redisClusterNodeIterator *iter) {
     if (iter->retries_left <= 0)
         return NULL;
 

--- a/hircluster.c
+++ b/hircluster.c
@@ -1436,7 +1436,7 @@ error:
     return REDIS_ERR;
 }
 
-int cluster_update_route(redisClusterContext *cc) {
+int redisClusterUpdateSlotmap(redisClusterContext *cc) {
     int ret;
     int flag_err_not_set = 1;
     redisClusterNode *node;
@@ -1547,7 +1547,7 @@ static int _redisClusterConnect2(redisClusterContext *cc) {
         return REDIS_ERR;
     }
 
-    return cluster_update_route(cc);
+    return redisClusterUpdateSlotmap(cc);
 }
 
 /* Connect to a Redis cluster. On error the field error in the returned
@@ -1563,7 +1563,7 @@ static redisClusterContext *_redisClusterConnect(redisClusterContext *cc,
         return cc;
     }
 
-    cluster_update_route(cc);
+    redisClusterUpdateSlotmap(cc);
 
     return cc;
 }
@@ -2333,7 +2333,7 @@ ask_retry:
                     /* Deferred update route using the node that sent the
                      * redirect. */
                     c_updating_route = c;
-                } else if (cluster_update_route(cc) == REDIS_OK) {
+                } else if (redisClusterUpdateSlotmap(cc) == REDIS_OK) {
                     /* Synchronous update route successful using new connection. */
                     cc->err = 0;
                     cc->errstr[0] = '\0';
@@ -2412,7 +2412,7 @@ done:
             /* Clear error and update synchronously using another node. */
             cc->err = 0;
             cc->errstr[0] = '\0';
-            if (cluster_update_route(cc) != REDIS_OK) {
+            if (redisClusterUpdateSlotmap(cc) != REDIS_OK) {
                 /* Clear the reply to indicate failure. */
                 freeReplyObject(reply);
                 reply = NULL;
@@ -3535,7 +3535,7 @@ void redisClusterReset(redisClusterContext *cc) {
     }
 
     if (cc->need_update_route) {
-        status = cluster_update_route(cc);
+        status = redisClusterUpdateSlotmap(cc);
         if (status != REDIS_OK) {
             /* Specific error already set */
             return;

--- a/hircluster.h
+++ b/hircluster.h
@@ -267,8 +267,10 @@ int redisClusterGetReply(redisClusterContext *cc, void **reply);
 /* Reset context after a performed pipelining */
 void redisClusterReset(redisClusterContext *cc);
 
+/* Update the slotmap by querying any node. */
+int redisClusterUpdateSlotmap(redisClusterContext *cc);
+
 /* Internal functions */
-int cluster_update_route(redisClusterContext *cc);
 redisContext *ctx_get_by_node(redisClusterContext *cc, redisClusterNode *node);
 struct dict *parse_cluster_nodes(redisClusterContext *cc, char *str,
                                  int str_len, int flags);
@@ -337,6 +339,7 @@ redisClusterNode *redisClusterGetNodeByKey(redisClusterContext *cc, char *key);
 
 /* Old names of renamed functions and types, kept for backward compatibility. */
 #ifndef HIRCLUSTER_NO_OLD_NAMES
+#define cluster_update_route redisClusterUpdateSlotmap
 #define initNodeIterator redisClusterInitNodeIterator
 #define nodeNext redisClusterNodeNext
 #define redisClusterConnectNonBlock redisClusterConnect

--- a/hircluster.h
+++ b/hircluster.h
@@ -96,9 +96,6 @@ typedef struct redisClusterNode {
     struct hiarray *importing; /* copen_slot[] */
 } redisClusterNode;
 
-/* Deprecated type, kept for backward compatibility */
-typedef struct redisClusterNode cluster_node;
-
 typedef struct cluster_slot {
     uint32_t start;
     uint32_t end;
@@ -165,12 +162,12 @@ typedef struct redisClusterAsyncContext {
 
 } redisClusterAsyncContext;
 
-typedef struct nodeIterator {
+typedef struct redisClusterNodeIterator {
     redisClusterContext *cc;
     uint64_t route_version;
     int retries_left;
     dictIterator di;
-} nodeIterator;
+} redisClusterNodeIterator;
 
 /*
  * Synchronous API
@@ -180,8 +177,6 @@ redisClusterContext *redisClusterConnect(const char *addrs, int flags);
 redisClusterContext *redisClusterConnectWithTimeout(const char *addrs,
                                                     const struct timeval tv,
                                                     int flags);
-/* Deprecated function, replaced by redisClusterConnect() */
-redisClusterContext *redisClusterConnectNonBlock(const char *addrs, int flags);
 int redisClusterConnect2(redisClusterContext *cc);
 
 redisClusterContext *redisClusterContextInit(void);
@@ -332,12 +327,22 @@ redisAsyncContext *actx_get_by_node(redisClusterAsyncContext *acc,
                                     redisClusterNode *node);
 
 /* Cluster node iterator functions */
-void initNodeIterator(nodeIterator *iter, redisClusterContext *cc);
-redisClusterNode *nodeNext(nodeIterator *iter);
+void redisClusterInitNodeIterator(redisClusterNodeIterator *iter,
+                                  redisClusterContext *cc);
+redisClusterNode *redisClusterNodeNext(redisClusterNodeIterator *iter);
 
 /* Helper functions */
 unsigned int redisClusterGetSlotByKey(char *key);
 redisClusterNode *redisClusterGetNodeByKey(redisClusterContext *cc, char *key);
+
+/* Old names of renamed functions and types, kept for backward compatibility. */
+#ifndef HIRCLUSTER_NO_OLD_NAMES
+#define initNodeIterator redisClusterInitNodeIterator
+#define nodeNext redisClusterNodeNext
+#define redisClusterConnectNonBlock redisClusterConnect
+typedef struct redisClusterNode cluster_node;
+typedef struct redisClusterNodeIterator nodeIterator;
+#endif
 
 #ifdef __cplusplus
 }

--- a/hiredis_cluster.def
+++ b/hiredis_cluster.def
@@ -7,8 +7,6 @@
 	dictInitIterator
 	dictNext
         hiarray_get
-	initNodeIterator
-	nodeNext
 	parse_cluster_nodes
 	parse_cluster_slots
 	redisClusterAppendCommand
@@ -32,7 +30,6 @@
 	redisClusterCommandToNode
 	redisClusterConnect
 	redisClusterConnect2
-	redisClusterConnectNonBlock
 	redisClusterConnectWithTimeout
 	redisClusterContextInit
 	redisClusterFormattedCommand
@@ -40,6 +37,8 @@
 	redisClusterGetNodeByKey
 	redisClusterGetReply
 	redisClusterGetSlotByKey
+	redisClusterInitNodeIterator
+	redisClusterNodeNext
 	redisClusterReset
 	redisClusterSetConnectCallback
 	redisClusterSetEventCallback

--- a/hiredis_cluster.def
+++ b/hiredis_cluster.def
@@ -1,6 +1,5 @@
  EXPORTS
 	actx_get_by_node
-	cluster_update_route
         command_destroy
         command_get
 	ctx_get_by_node
@@ -55,6 +54,7 @@
 	redisClusterSetOptionTimeout
 	redisClusterSetOptionUsername
 	redisClusterSetOptionPassword
+	redisClusterUpdateSlotmap
 	redisClustervAppendCommand
 	redisClustervAsyncCommand
 	redisClustervCommand

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -238,9 +238,9 @@ void test_command_timeout(void) {
     int status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
 
-    nodeIterator ni;
-    initNodeIterator(&ni, cc);
-    redisClusterNode *node = nodeNext(&ni);
+    redisClusterNodeIterator ni;
+    redisClusterInitNodeIterator(&ni, cc);
+    redisClusterNode *node = redisClusterNodeNext(&ni);
     assert(node);
 
     /* Simulate a command timeout */
@@ -272,9 +272,9 @@ void test_command_timeout_set_while_connected(void) {
     int status = redisClusterConnect2(cc);
     ASSERT_MSG(status == REDIS_OK, cc->errstr);
 
-    nodeIterator ni;
-    initNodeIterator(&ni, cc);
-    redisClusterNode *node = nodeNext(&ni);
+    redisClusterNodeIterator ni;
+    redisClusterInitNodeIterator(&ni, cc);
+    redisClusterNode *node = redisClusterNodeNext(&ni);
     assert(node);
 
     redisReply *reply;
@@ -593,9 +593,9 @@ void test_async_command_timeout(void) {
     assert(status == REDIS_OK);
     assert(acc->cc->err == 0);
 
-    nodeIterator ni;
-    initNodeIterator(&ni, acc->cc);
-    redisClusterNode *node = nodeNext(&ni);
+    redisClusterNodeIterator ni;
+    redisClusterInitNodeIterator(&ni, acc->cc);
+    redisClusterNode *node = redisClusterNodeNext(&ni);
     assert(node);
 
     /* Simulate a command timeout and expect a timeout error */

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -364,9 +364,9 @@ void test_alloc_failure_handling(void) {
 
         /* Get a destination node to migrate the slot to. */
         redisClusterNode *dstNode;
-        nodeIterator ni;
-        initNodeIterator(&ni, cc);
-        while ((dstNode = nodeNext(&ni)) != NULL) {
+        redisClusterNodeIterator ni;
+        redisClusterInitNodeIterator(&ni, cc);
+        while ((dstNode = redisClusterNodeNext(&ni)) != NULL) {
             if (dstNode != srcNode)
                 break;
         }
@@ -449,9 +449,9 @@ void test_alloc_failure_handling(void) {
         /* MOVED triggers a slotmap update which currently replaces all cluster_node
          * objects. We can get the new objects by searching for its server ports.
          * This enables us to migrate the slot back to the original node. */
-        initNodeIterator(&ni, cc);
+        redisClusterInitNodeIterator(&ni, cc);
         redisClusterNode *node;
-        while ((node = nodeNext(&ni)) != NULL) {
+        while ((node = redisClusterNodeNext(&ni)) != NULL) {
             if (node->port == srcPort)
                 srcNode = node;
             if (node->port == dstPort)

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -29,11 +29,11 @@ void test_command_to_single_node(redisClusterContext *cc) {
 
 void test_command_to_all_nodes(redisClusterContext *cc) {
 
-    nodeIterator ni;
-    initNodeIterator(&ni, cc);
+    redisClusterNodeIterator ni;
+    redisClusterInitNodeIterator(&ni, cc);
 
     redisClusterNode *node;
-    while ((node = nodeNext(&ni)) != NULL) {
+    while ((node = redisClusterNodeNext(&ni)) != NULL) {
 
         redisReply *reply;
         reply = redisClusterCommandToNode(cc, node, "DBSIZE");
@@ -200,11 +200,11 @@ void test_pipeline_to_single_node(redisClusterContext *cc) {
 
 void test_pipeline_to_all_nodes(redisClusterContext *cc) {
 
-    nodeIterator ni;
-    initNodeIterator(&ni, cc);
+    redisClusterNodeIterator ni;
+    redisClusterInitNodeIterator(&ni, cc);
 
     redisClusterNode *node;
-    while ((node = nodeNext(&ni)) != NULL) {
+    while ((node = redisClusterNodeNext(&ni)) != NULL) {
         int status = redisClusterAppendCommandToNode(cc, node, "DBSIZE");
         ASSERT_MSG(status == REDIS_OK, cc->errstr);
     }
@@ -444,13 +444,13 @@ void test_async_to_all_nodes(void) {
     status = redisClusterLibeventAttach(acc, base);
     assert(status == REDIS_OK);
 
-    nodeIterator ni;
-    initNodeIterator(&ni, acc->cc);
+    redisClusterNodeIterator ni;
+    redisClusterInitNodeIterator(&ni, acc->cc);
 
     ExpectedResult r1 = {.type = REDIS_REPLY_INTEGER};
 
     redisClusterNode *node;
-    while ((node = nodeNext(&ni)) != NULL) {
+    while ((node = redisClusterNodeNext(&ni)) != NULL) {
 
         status = redisClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
                                                 "DBSIZE");

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -10,13 +10,13 @@ static int redis_version_minor;
 /* Helper to extract Redis version information. */
 #define REDIS_VERSION_FIELD "redis_version:"
 void load_redis_version(redisClusterContext *cc) {
-    nodeIterator ni;
+    redisClusterNodeIterator ni;
     redisClusterNode *node;
     char *eptr, *s, *e;
     redisReply *reply = NULL;
 
-    initNodeIterator(&ni, cc);
-    if ((node = nodeNext(&ni)) == NULL)
+    redisClusterInitNodeIterator(&ni, cc);
+    if ((node = redisClusterNodeNext(&ni)) == NULL)
         goto abort;
 
     reply = redisClusterCommandToNode(cc, node, "INFO");


### PR DESCRIPTION
Rename node iterator type and its functions:
  `nodeIterator`         to `redisClusterNodeIterator`
  `initNodeIterator(..)` to `redisClusterInitNodeIterator(..)`
  `nodeNext(..)`         to  `redisClusterNodeNext(..)`

Renaming of:
  `cluster_update_route` to `redisClusterUpdateSlotMap()`
    
Old names are still defined for backward compability,
but `HIRCLUSTER_NO_OLD_NAMES` can be defined when backward compability with old types or function names is not needed.
