### PR TITLE
Fix code for XREAD and XREADGROUP and add test case

### DIFF
--- a/tests/ut_parse_cmd.c
+++ b/tests/ut_parse_cmd.c
@@ -131,6 +131,16 @@ void test_redis_parse_cmd_xgroup_destroy_ok(void) {
     command_destroy(c);
 }
 
+void test_redis_parse_cmd_xreadgroup_ok(void) {
+    struct cmd *c = command_get();
+    int len = redisFormatCommand(&c->cmd, "XREADGROUP GROUP XX XX COUNT 1 STREAMS mystream >");
+    ASSERT_MSG(len >= 0, "Format command error");
+    c->clen = len;
+    redis_parse_cmd(c);
+    ASSERT_KEYS(c, "mystream");
+    command_destroy(c);
+}
+
 int main(void) {
     test_redis_parse_error_nonresp();
     test_redis_parse_cmd_get();
@@ -140,5 +150,6 @@ int main(void) {
     test_redis_parse_cmd_xgroup_no_subcommand();
     test_redis_parse_cmd_xgroup_destroy_no_key();
     test_redis_parse_cmd_xgroup_destroy_ok();
+    test_redis_parse_cmd_xreadgroup_ok();
     return 0;
 }

--- a/tests/ut_parse_cmd.c
+++ b/tests/ut_parse_cmd.c
@@ -133,7 +133,8 @@ void test_redis_parse_cmd_xgroup_destroy_ok(void) {
 
 void test_redis_parse_cmd_xreadgroup_ok(void) {
     struct cmd *c = command_get();
-    int len = redisFormatCommand(&c->cmd, "XREADGROUP GROUP XX XX COUNT 1 STREAMS mystream >");
+    int len = redisFormatCommand(
+        &c->cmd, "XREADGROUP GROUP XX XX COUNT 1 STREAMS mystream >");
     ASSERT_MSG(len >= 0, "Format command error");
     c->clen = len;
     redis_parse_cmd(c);

--- a/tests/ut_parse_cmd.c
+++ b/tests/ut_parse_cmd.c
@@ -146,8 +146,8 @@ void test_redis_parse_cmd_xreadgroup_ok(void) {
 
 void test_redis_parse_cmd_xread_ok(void) {
     struct cmd *c = command_get();
-    int len = redisFormatCommand(
-        &c->cmd, "XREAD BLOCK 42 STREAMS mystream another $ $");
+    int len = redisFormatCommand(&c->cmd,
+                                 "XREAD BLOCK 42 STREAMS mystream another $ $");
     ASSERT_MSG(len >= 0, "Format command error");
     c->clen = len;
     redis_parse_cmd(c);

--- a/tests/ut_parse_cmd.c
+++ b/tests/ut_parse_cmd.c
@@ -133,8 +133,21 @@ void test_redis_parse_cmd_xgroup_destroy_ok(void) {
 
 void test_redis_parse_cmd_xreadgroup_ok(void) {
     struct cmd *c = command_get();
+    /* Use group name and consumer name "streams" just to try to confuse the
+     * parser. The parser shouldn't mistake those for the STREAMS keyword. */
     int len = redisFormatCommand(
-        &c->cmd, "XREADGROUP GROUP XX XX COUNT 1 STREAMS mystream >");
+        &c->cmd, "XREADGROUP GROUP streams streams COUNT 1 streams mystream >");
+    ASSERT_MSG(len >= 0, "Format command error");
+    c->clen = len;
+    redis_parse_cmd(c);
+    ASSERT_KEYS(c, "mystream");
+    command_destroy(c);
+}
+
+void test_redis_parse_cmd_xread_ok(void) {
+    struct cmd *c = command_get();
+    int len = redisFormatCommand(
+        &c->cmd, "XREAD BLOCK 42 STREAMS mystream another $ $");
     ASSERT_MSG(len >= 0, "Format command error");
     c->clen = len;
     redis_parse_cmd(c);
@@ -152,5 +165,6 @@ int main(void) {
     test_redis_parse_cmd_xgroup_destroy_no_key();
     test_redis_parse_cmd_xgroup_destroy_ok();
     test_redis_parse_cmd_xreadgroup_ok();
+    test_redis_parse_cmd_xread_ok();
     return 0;
 }


### PR DESCRIPTION
The code for finding keys in XREAD and XREADGROUP commands was untested and incorrect. Here it is fixed and a test case is added.

Fixes #186

