### PR TITLE
Update connect-error-using-cluster-nodes-test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,7 +207,7 @@ add_test(NAME timeout-handling-test
          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
 add_test(NAME connect-error-using-cluster-nodes-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/connect-error-using-cluster-nodes-test.sh"
-                 "$<TARGET_FILE:clusterclient_async>"
+                 "$<TARGET_FILE:clusterclient>"
          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
 add_test(NAME command-from-callback-test
          COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/command-from-callback-test.sh"

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -8,6 +8,10 @@
  *           Will send following commands using the `..ToNode()` API and a
  *           cluster node iterator to send each command to all known nodes.
  *
+ * Exit statuses this program can return:
+ *   0 - Successful execution of program.
+ *   1 - The required argument "HOST:PORT" is not given.
+ *   2 - Client failed to get initial slotmap from given "HOST:PORT".
  */
 
 #include "hircluster.h"
@@ -91,7 +95,7 @@ int main(int argc, char **argv) {
 
     if (redisClusterConnect2(cc) != REDIS_OK) {
         printf("Connect error: %s\n", cc->errstr);
-        exit(1);
+        exit(2);
     }
 
     char command[256];

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -71,7 +71,8 @@ int main(int argc, char **argv) {
     }
 
     if (argindex >= argc) {
-        fprintf(stderr, "Usage: clusterclient [--events] [--use-cluster-nodes] HOST:PORT\n");
+        fprintf(stderr, "Usage: clusterclient [--events] [--use-cluster-nodes] "
+                        "HOST:PORT\n");
         exit(1);
     }
     const char *initnode = argv[argindex];

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -10,7 +10,7 @@
  *
  * Exit statuses this program can return:
  *   0 - Successful execution of program.
- *   1 - The required argument "HOST:PORT" is not given.
+ *   1 - Bad arguments.
  *   2 - Client failed to get initial slotmap from given "HOST:PORT".
  */
 
@@ -71,6 +71,7 @@ int main(int argc, char **argv) {
             use_cluster_slots = 0;
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[argindex]);
+            exit(1);
         }
     }
 

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -54,24 +54,24 @@ void eventCallback(const redisClusterContext *cc, int event, void *privdata) {
 }
 
 int main(int argc, char **argv) {
-    int use_cluster_slots = 1;
     int show_events = 0;
+    int use_cluster_slots = 1;
     int send_to_all = 0;
 
     int argindex;
     for (argindex = 1; argindex < argc && argv[argindex][0] == '-';
          argindex++) {
-        if (strcmp(argv[argindex], "--use-cluster-nodes") == 0) {
-            use_cluster_slots = 0;
-        } else if (strcmp(argv[argindex], "--events") == 0) {
+        if (strcmp(argv[argindex], "--events") == 0) {
             show_events = 1;
+        } else if (strcmp(argv[argindex], "--use-cluster-nodes") == 0) {
+            use_cluster_slots = 0;
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[argindex]);
         }
     }
 
     if (argindex >= argc) {
-        fprintf(stderr, "Usage: clusterclient [--events] HOST:PORT\n");
+        fprintf(stderr, "Usage: clusterclient [--events] [--use-cluster-nodes] HOST:PORT\n");
         exit(1);
     }
     const char *initnode = argv[argindex];
@@ -89,8 +89,8 @@ int main(int argc, char **argv) {
     }
 
     if (redisClusterConnect2(cc) != REDIS_OK) {
-        fprintf(stderr, "Connect error: %s\n", cc->errstr);
-        exit(2);
+        printf("Connect error: %s\n", cc->errstr);
+        exit(1);
     }
 
     char command[256];

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -54,13 +54,16 @@ void eventCallback(const redisClusterContext *cc, int event, void *privdata) {
 }
 
 int main(int argc, char **argv) {
+    int use_cluster_slots = 1;
     int show_events = 0;
     int send_to_all = 0;
 
     int argindex;
     for (argindex = 1; argindex < argc && argv[argindex][0] == '-';
          argindex++) {
-        if (strcmp(argv[argindex], "--events") == 0) {
+        if (strcmp(argv[argindex], "--use-cluster-nodes") == 0) {
+            use_cluster_slots = 0;
+        } else if (strcmp(argv[argindex], "--events") == 0) {
             show_events = 1;
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[argindex]);
@@ -78,14 +81,16 @@ int main(int argc, char **argv) {
     redisClusterContext *cc = redisClusterContextInit();
     redisClusterSetOptionAddNodes(cc, initnode);
     redisClusterSetOptionConnectTimeout(cc, timeout);
-    redisClusterSetOptionRouteUseSlots(cc);
+    if (use_cluster_slots) {
+        redisClusterSetOptionRouteUseSlots(cc);
+    }
     if (show_events) {
         redisClusterSetEventCallback(cc, eventCallback, NULL);
     }
 
     if (redisClusterConnect2(cc) != REDIS_OK) {
         fprintf(stderr, "Connect error: %s\n", cc->errstr);
-        exit(100);
+        exit(2);
     }
 
     char command[256];

--- a/tests/scripts/connect-error-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-error-using-cluster-nodes-test.sh
@@ -44,7 +44,7 @@ if [ $serverexit -ne 0 ]; then
 fi
 
 # Check exit status on client, which SHOULD fail.
-if [ $clientexit -ne 1 ]; then
+if [ $clientexit -ne 2 ]; then
     echo "$clientprog exited with status $clientexit"
     exit $clientexit
 fi

--- a/tests/scripts/connect-error-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-error-using-cluster-nodes-test.sh
@@ -11,7 +11,7 @@
 #
 # Usage: $0 /path/to/clusterclient-binary
 
-clientprog=${1:-./clusterclient_async}
+clientprog=${1:-./clusterclient}
 testname=connect-error-using-cluster-nodes-test
 
 # Sync process just waiting for server to be ready to accept connection.
@@ -31,7 +31,7 @@ server=$!
 wait $syncpid;
 
 # Run client and use CLUSTER NODES to get topology
-timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out"
+timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" 2>&1
 clientexit=$?
 
 # Wait for server to exit
@@ -50,7 +50,7 @@ if [ $clientexit -ne 2 ]; then
 fi
 
 # Check the output from clusterclient
-printf 'Connect error: No slot information\n' | cmp "$testname.out" - || exit 99
+printf 'Connect error: No slot information\n' | diff -u - "$testname.out" || exit 99
 
 # Clean up
 rm "$testname.out"

--- a/tests/scripts/connect-error-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-error-using-cluster-nodes-test.sh
@@ -31,7 +31,7 @@ server=$!
 wait $syncpid;
 
 # Run client and use CLUSTER NODES to get topology
-timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" 2>&1
+timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out"
 clientexit=$?
 
 # Wait for server to exit
@@ -44,7 +44,7 @@ if [ $serverexit -ne 0 ]; then
 fi
 
 # Check exit status on client, which SHOULD fail.
-if [ $clientexit -ne 2 ]; then
+if [ $clientexit -ne 1 ]; then
     echo "$clientprog exited with status $clientexit"
     exit $clientexit
 fi


### PR DESCRIPTION
Use clusterclient for this testcase instead of clusterclient_async since
the testcase aims to test failures in the initial *blocking* slotmap update.

clusterclient now also handles the flag `--use-cluster-nodes` to update
the slotmap using the command "CLUSTER NODES".