### PR TITLE
Fix the check for ":0@0" in CLUSTER NODES result

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -960,8 +960,8 @@ dict *parse_cluster_nodes(redisClusterContext *cc, char *str, int str_len,
                 goto error;
             }
 
-            // the address string is ":0", skip this node.
-            if (sdslen(part[1]) == 2 && strcmp(part[1], ":0") == 0) {
+            // if the address string starts with ":0", skip this node.
+            if (sdslen(part[1]) >= 2 && part[1][0] == ':' && part[1][1] == '0') {
                 sdsfreesplitres(part, count_part);
                 count_part = 0;
                 part = NULL;

--- a/hircluster.c
+++ b/hircluster.c
@@ -961,7 +961,7 @@ dict *parse_cluster_nodes(redisClusterContext *cc, char *str, int str_len,
             }
 
             // if the address string starts with ":0", skip this node.
-            if (sdslen(part[1]) >= 2 && part[1][0] == ':' && part[1][1] == '0') {
+            if (sdslen(part[1]) >= 2 && memcmp(part[1], ":0", 2) == 0) {
                 sdsfreesplitres(part, count_part);
                 count_part = 0;
                 part = NULL;


### PR DESCRIPTION
The current implementation assumes that the entire part is only 2 characters when the IP and port are not set (IP is empty and port is 0). However, this is incorrect because the '@cport' is also present so the current check fails. Additionally, there may be an optional ',hostname' as well which is not accounted for.

The fix here simply changes the logic from "if the part is ':0'" to "if the part starts with ':0'".
