### PR TITLE
Invoke all callbacks during redisClusterAsyncDisconnect()

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -4404,7 +4404,7 @@ void redisClusterAsyncDisconnect(redisClusterAsyncContext *acc) {
 
         ac = node->acon;
 
-        if (ac == NULL || ac->err) {
+        if (ac == NULL) {
             continue;
         }
 


### PR DESCRIPTION
Don't skip calling redisAsyncDisconnect(context) on contexts with errors.
This makes sure that all pending request callbacks are invoked with a NULL reply, not only on contexts without errors.

Attempted to add a testcase covering this scenario, but could not reproduce it using simulated-redis tests.

Fixes #203 