### PR TITLE
Set read-only permission for Github Actions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   checkers:
     name: Run static checkers

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron:  '0 1 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/redis_compability.yml
+++ b/.github/workflows/redis_compability.yml
@@ -2,6 +2,9 @@ name: Redis compatibility testing
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   redis-comp:
     name: Redis ${{ matrix.redis-version }}


### PR DESCRIPTION
This sets the default permission for CI workflows to only be able to read from the repository (scope: "contents").

A compromised action will not be able to modify the repo or even steal secrets since all other permission-scopes are implicit set to "none", i.e. not permitted.
More about permissions and scope can be found here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions