### PR TITLE
Fix build issue in CI for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Prepare
         run: |
           choco install -y ninja
-          vcpkg install --triplet x64-windows libevent
+          vcpkg install --triplet x64-windows pkgconf libevent
       - name: Build
         run: |
           mkdir build && cd build


### PR DESCRIPTION
Install the missing vcpkg `pkgconf` since it's not longer preinstalled in runner `windows-latest`.