### PR TITLE
Setup compiler and CMake in CI using a new Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-11, clang-12]
-        cmake-version: [3.19.7]
+        compiler: [gcc-13, clang-18]
+        cmake-version: [3.29.3]
         cmake-build-type: [Release, RelWithDebInfo]
         sanitizer: ["", thread, undefined, leak, address]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,32 +21,38 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gcc-11, clang-12]
-        cmake-version: [3.19]
+        cmake-version: [3.19.7]
         cmake-build-type: [Release, RelWithDebInfo]
         sanitizer: ["", thread, undefined, leak, address]
         include:
           - compiler: gcc-7
-            cmake-version: 3.14
+            cmake-version: 3.14.5
             cmake-build-type: Release
             sanitizer: ""
           - compiler: gcc-8
-            cmake-version: 3.15
+            cmake-version: 3.15.4
             cmake-build-type: Release
             sanitizer: ""
           - compiler: clang-7
-            cmake-version: 3.17
+            cmake-version: 3.17.3
             cmake-build-type: Release
             sanitizer: ""
           - compiler: clang-9
-            cmake-version: 3.18
+            cmake-version: 3.18.6
             cmake-build-type: Release
             sanitizer: ""
 
     steps:
-    - name: Prepare
+    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+    - name: Prepare build tools
+      uses: aminya/setup-cpp@290824452986e378826155f3379d31bce8753d76 # v0.37.0
+      with:
+        compiler: ${{ matrix.compiler }}
+        cmake: ${{ matrix.cmake-version }}
+    - name: Install cached APT packages
       uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
       with:
-        packages: libevent-dev libuv1-dev libev-dev libglib2.0-dev ${{ matrix.compiler }}
+        packages: libevent-dev libuv1-dev libev-dev libglib2.0-dev
         version: 1.0
     - name: Install hiredis
       env:
@@ -55,17 +61,10 @@ jobs:
         curl -L https://github.com/redis/hiredis/archive/v${VERSION}.tar.gz | tar -xz
         cmake -S hiredis-${VERSION} -B hiredis-build -DENABLE_SSL=ON
         sudo make -C hiredis-build install
-    - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
-      with:
-        cmake-version: ${{ matrix.cmake-version }}
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Create build folder
       run: cmake -E make_directory build
     - name: Generate makefiles
       shell: bash
-      env:
-        CC: ${{ matrix.compiler }}
       working-directory: build
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DENABLE_IPV6_TESTS=ON -DDOWNLOAD_HIREDIS=OFF -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
     - name: Build
@@ -93,6 +92,9 @@ jobs:
       env:
         CC: ${{ matrix.compiler }}
       run: |
+        # Unset env. variables set by action 'aminya/setup-cpp'
+        # since they affects library installation and linkage.
+        unset LDFLAGS LIBRARY_PATH
         examples/using_cmake_externalproject/build.sh
         examples/using_cmake_separate/build.sh
         examples/using_cmake_and_make_mixed/build.sh

--- a/examples/src/example_async.c
+++ b/examples/src/example_async.c
@@ -6,7 +6,7 @@
 void getCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
     redisReply *reply = (redisReply *)r;
     if (reply == NULL) {
-        if (cc->errstr) {
+        if (cc->err) {
             printf("errstr: %s\n", cc->errstr);
         }
         return;
@@ -20,7 +20,7 @@ void getCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
 void setCallback(redisClusterAsyncContext *cc, void *r, void *privdata) {
     redisReply *reply = (redisReply *)r;
     if (reply == NULL) {
-        if (cc->errstr) {
+        if (cc->err) {
             printf("errstr: %s\n", cc->errstr);
         }
         return;

--- a/examples/using_cmake_and_make_mixed/build.sh
+++ b/examples/using_cmake_and_make_mixed/build.sh
@@ -8,7 +8,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.1.0
+hiredis_version=1.2.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using GNU Make

--- a/examples/using_cmake_externalproject/CMakeLists.txt
+++ b/examples/using_cmake_externalproject/CMakeLists.txt
@@ -5,7 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(hiredis
   PREFIX hiredis
   GIT_REPOSITORY  https://github.com/redis/hiredis
-  GIT_TAG         v1.0.2
+  GIT_TAG         v1.2.0
   CMAKE_ARGS
     "-DCMAKE_C_FLAGS:STRING=-std=c99"
     "-DENABLE_SSL:BOOL=ON"

--- a/examples/using_cmake_separate/build.sh
+++ b/examples/using_cmake_separate/build.sh
@@ -9,7 +9,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.1.0
+hiredis_version=1.2.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using CMake

--- a/examples/using_make/build.sh
+++ b/examples/using_make/build.sh
@@ -8,7 +8,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.0.2
+hiredis_version=1.2.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using GNU Make


### PR DESCRIPTION
APT packages are sometimes removed so lets use the Github Action [aminya/setup-cpp](https://github.com/aminya/setup-cpp) to setup the compiler,
which fixes current CI issues with missing compiler. This action will also install the requested CMake version.

This PR includes the following changes:
- Use latest GCC, Clang and CMake in CI
- Fix warnings in examples



