### PR TITLE
Use correct signature for `event_callback_fn` (libevent2) in tests

### DIFF
--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -50,7 +50,7 @@ int num_running = 0;
 int resend_failed_cmd = 0;
 int send_to_all = 0;
 
-void sendNextCommand(int, short, void *);
+void sendNextCommand(evutil_socket_t, short, void *);
 
 void printReply(const redisReply *reply) {
     switch (reply->type) {
@@ -98,7 +98,7 @@ void replyCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
     }
 }
 
-void sendNextCommand(int fd, short kind, void *arg) {
+void sendNextCommand(evutil_socket_t fd, short kind, void *arg) {
     UNUSED(fd);
     UNUSED(kind);
     redisClusterAsyncContext *acc = arg;

--- a/tests/clusterclient_reconnect_async.c
+++ b/tests/clusterclient_reconnect_async.c
@@ -20,7 +20,7 @@
 /* Unfortunately there is no error code for this error to match */
 #define REDIS_ENOCLUSTER "ERR This instance has cluster support disabled"
 
-void sendNextCommand(int, short, void *);
+void sendNextCommand(evutil_socket_t, short, void *);
 
 void connectToRedis(redisClusterAsyncContext *acc) {
     /* reset Redis context in case of reconnect */
@@ -60,7 +60,7 @@ void replyCallback(redisClusterAsyncContext *acc, void *r, void *privdata) {
     event_base_once(acc->adapter, -1, EV_TIMEOUT, sendNextCommand, acc, NULL);
 }
 
-void sendNextCommand(int fd, short kind, void *arg) {
+void sendNextCommand(evutil_socket_t fd, short kind, void *arg) {
     UNUSED(fd);
     UNUSED(kind);
     redisClusterAsyncContext *acc = arg;


### PR DESCRIPTION
Use the correct libevent2 type `evutil_socket_t` instead of `int` when implementing the libevent2 callback function in our tests. On Windows `evutil_socket_t` is a `intptr_t` (long long int) and this fixes the build errors for gcc-14 on Windows/MinGW.

[Defined in include/event2/event.h:](http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/event_8h.html)
typedef void(* 	event_callback_fn )(evutil_socket_t, short, void *)