### PR TITLE
Add redisClustervCommandToNode and redisClustervAppendCommandToNode to library API

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -3034,6 +3034,17 @@ void *redisClustervCommand(redisClusterContext *cc, const char *format,
     return reply;
 }
 
+void *redisClusterCommand(redisClusterContext *cc, const char *format, ...) {
+    va_list ap;
+    redisReply *reply = NULL;
+
+    va_start(ap, format);
+    reply = redisClustervCommand(cc, format, ap);
+    va_end(ap);
+
+    return reply;
+}
+
 void *redisClustervCommandToNode(redisClusterContext *cc,
                                  redisClusterNode *node, const char *format,
                                  va_list ap) {
@@ -3084,17 +3095,6 @@ void *redisClustervCommandToNode(redisClusterContext *cc,
             cc->errstr[0] = '\0';
         }
     }
-
-    return reply;
-}
-
-void *redisClusterCommand(redisClusterContext *cc, const char *format, ...) {
-    va_list ap;
-    redisReply *reply = NULL;
-
-    va_start(ap, format);
-    reply = redisClustervCommand(cc, format, ap);
-    va_end(ap);
 
     return reply;
 }
@@ -3245,6 +3245,22 @@ int redisClustervAppendCommand(redisClusterContext *cc, const char *format,
     return ret;
 }
 
+int redisClusterAppendCommand(redisClusterContext *cc, const char *format,
+                              ...) {
+    int ret;
+    va_list ap;
+
+    if (cc == NULL || format == NULL) {
+        return REDIS_ERR;
+    }
+
+    va_start(ap, format);
+    ret = redisClustervAppendCommand(cc, format, ap);
+    va_end(ap);
+
+    return ret;
+}
+
 int redisClustervAppendCommandToNode(redisClusterContext *cc,
                                      redisClusterNode *node, const char *format,
                                      va_list ap) {
@@ -3306,22 +3322,6 @@ oom:
     command_destroy(command);
     __redisClusterSetError(cc, REDIS_ERR_OOM, "Out of memory");
     return REDIS_ERR;
-}
-
-int redisClusterAppendCommand(redisClusterContext *cc, const char *format,
-                              ...) {
-    int ret;
-    va_list ap;
-
-    if (cc == NULL || format == NULL) {
-        return REDIS_ERR;
-    }
-
-    va_start(ap, format);
-    ret = redisClustervAppendCommand(cc, format, ap);
-    va_end(ap);
-
-    return ret;
 }
 
 int redisClusterAppendCommandToNode(redisClusterContext *cc,

--- a/hircluster.h
+++ b/hircluster.h
@@ -245,6 +245,9 @@ void *redisClusterCommandToNode(redisClusterContext *cc, redisClusterNode *node,
 /* Variadic using va_list */
 void *redisClustervCommand(redisClusterContext *cc, const char *format,
                            va_list ap);
+void *redisClustervCommandToNode(redisClusterContext *cc,
+                                 redisClusterNode *node, const char *format,
+                                 va_list ap);
 /* Using argc and argv */
 void *redisClusterCommandArgv(redisClusterContext *cc, int argc,
                               const char **argv, const size_t *argvlen);
@@ -265,6 +268,9 @@ int redisClusterAppendCommandToNode(redisClusterContext *cc,
 /* Variadic using va_list */
 int redisClustervAppendCommand(redisClusterContext *cc, const char *format,
                                va_list ap);
+int redisClustervAppendCommandToNode(redisClusterContext *cc,
+                                     redisClusterNode *node, const char *format,
+                                     va_list ap);
 /* Using argc and argv */
 int redisClusterAppendCommandArgv(redisClusterContext *cc, int argc,
                                   const char **argv, const size_t *argvlen);


### PR DESCRIPTION
Closes #230.

I did not add new tests as original redisClusterv* APIs are not tested directly, and test coverage should not change. Please comment in this PR if separate specialized tests are required.

The only disadvantage of this PR that I see, is that va_start() is called in more cases. It can add some (albeit minuscule) overhead, but all such cases end in an error anyway.