### PR TITLE
Free `cluster_async_data` in cases where hiredis don't takes ownership

### DIFF
--- a/hircluster.c
+++ b/hircluster.c
@@ -4232,6 +4232,7 @@ int redisClusterAsyncFormattedCommand(redisClusterAsyncContext *acc,
     status = redisAsyncFormattedCommand(ac, redisClusterAsyncCallback, cad, cmd,
                                         len);
     if (status != REDIS_OK) {
+        __redisClusterAsyncSetError(acc, ac->err, ac->errstr);
         goto error;
     }
 
@@ -4312,9 +4313,10 @@ int redisClusterAsyncFormattedCommandToNode(redisClusterAsyncContext *acc,
 
     status = redisAsyncFormattedCommand(ac, redisClusterAsyncCallback, cad, cmd,
                                         len);
-    if (status != REDIS_OK)
+    if (status != REDIS_OK) {
+        __redisClusterAsyncSetError(acc, ac->err, ac->errstr);
         goto error;
-
+    }
     return REDIS_OK;
 
 oom:

--- a/hircluster.c
+++ b/hircluster.c
@@ -4138,7 +4138,7 @@ int redisClusterAsyncFormattedCommand(redisClusterAsyncContext *acc,
     redisAsyncContext *ac;
     struct cmd *command = NULL;
     hilist *commands = NULL;
-    cluster_async_data *cad;
+    cluster_async_data *cad = NULL;
 
     if (acc == NULL) {
         return REDIS_ERR;
@@ -4225,6 +4225,7 @@ int redisClusterAsyncFormattedCommand(redisClusterAsyncContext *acc,
 
     cad->acc = acc;
     cad->command = command;
+    command = NULL; /* Memory ownership moved. */
     cad->callback = fn;
     cad->privdata = privdata;
 
@@ -4245,6 +4246,7 @@ oom:
     // passthrough
 
 error:
+    cluster_async_data_free(cad);
     command_destroy(command);
     if (commands != NULL) {
         listRelease(commands);
@@ -4303,6 +4305,7 @@ int redisClusterAsyncFormattedCommandToNode(redisClusterAsyncContext *acc,
 
     cad->acc = acc;
     cad->command = command;
+    command = NULL; /* Memory ownership moved. */
     cad->callback = fn;
     cad->privdata = privdata;
     cad->retry_count = NO_RETRY;
@@ -4319,6 +4322,7 @@ oom:
     // passthrough
 
 error:
+    cluster_async_data_free(cad);
     command_destroy(command);
     return REDIS_ERR;
 }


### PR DESCRIPTION
When hiredis API `redisAsyncFormattedCommand()` fail to push a given callback to its internal queue we need to free the memory of `cluster_async_data` (which is used as `privdata`).
Before #225 this could happen when sending a command right after initiating a disconnect, but now its mainly in OOM cases.

Make sure we also keep the error message from `redisAsyncFormattedCommand()`.

Fixes #229 