### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,25 +16,17 @@ jobs:
 
   ubuntu:
     name: ${{ matrix.cmake-build-type }}-build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }} sanitizer="${{ matrix.sanitizer }}"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-13, clang-18]
+        compiler: [gcc-14, clang-19]
         cmake-version: [3.29.3]
         cmake-build-type: [Release, RelWithDebInfo]
         sanitizer: ["", thread, undefined, leak, address]
         include:
-          - compiler: gcc-7
+          - compiler: gcc-9
             cmake-version: 3.14.5
-            cmake-build-type: Release
-            sanitizer: ""
-          - compiler: gcc-8
-            cmake-version: 3.15.4
-            cmake-build-type: Release
-            sanitizer: ""
-          - compiler: clang-7
-            cmake-version: 3.17.3
             cmake-build-type: Release
             sanitizer: ""
           - compiler: clang-9

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -8,12 +8,13 @@ permissions:
 jobs:
   valkey:
     name: Valkey ${{ matrix.valkey-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - valkey-version: 7.2.5
+          - valkey-version: '8.0.2'
+          - valkey-version: '7.2.5'
     steps:
       - name: Prepare
         uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
@@ -50,16 +51,14 @@ jobs:
 
   redis-comp:
     name: Redis ${{ matrix.redis-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - redis-version: 7.2.4
-          - redis-version: 7.0.15
-          - redis-version: 6.2.14
-          - redis-version: 6.0.20
-          - redis-version: 5.0.14
+          - redis-version: '7.2.4'
+          - redis-version: '7.0.15'
+          - redis-version: '6.2.14'
     steps:
       - name: Prepare
         uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3


### PR DESCRIPTION
- Replace runner `ubuntu-20.04` which will be removed 2025-04-01.
- Update to available compilers and add Valkey 8.0.2 to the DB test matrix.