### PR TITLE
dependabot: bundle multiple dependency updates in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Use the grouping feature in `dependabot` to bundle multiple updates into a single PR during the weekly check.