### PR TITLE
Use latest hiredis v1.3.0 as default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-14, clang-19]
-        cmake-version: [3.29.3]
+        compiler: [gcc-14, clang-20]
+        cmake-version: [3.31.8]
         cmake-build-type: [Release, RelWithDebInfo]
         sanitizer: ["", thread, undefined, leak, address]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,6 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-      - name: Prepare
-        run: |
-          brew install ninja
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         version: 1.0
     - name: Install hiredis
       env:
-        VERSION: 1.2.0
+        VERSION: 1.3.0
       run: |
         curl -L https://github.com/redis/hiredis/archive/v${VERSION}.tar.gz | tar -xz
         cmake -S hiredis-${VERSION} -B hiredis-build -DENABLE_SSL=ON

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -13,8 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - valkey-version: '8.0.2'
-          - valkey-version: '7.2.5'
+          - valkey-version: '8.1.2'
+          - valkey-version: '8.0.3'
+          - valkey-version: '7.2.9'
     steps:
       - name: Prepare
         uses: awalsh128/cache-apt-pkgs-action@7ca5f46d061ad9aa95863cd9b214dd48edef361d # v1.5.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(DOWNLOAD_HIREDIS)
       "Upgrade CMake or manually install 'hiredis' and use -DDOWNLOAD_HIREDIS=OFF")
   endif()
 
-  set(HIREDIS_VERSION "1.2.0")
+  set(HIREDIS_VERSION "1.3.0")
   message("Downloading dependency: hiredis v${HIREDIS_VERSION}")
 
   include(FetchContent)

--- a/examples/using_cmake_and_make_mixed/build.sh
+++ b/examples/using_cmake_and_make_mixed/build.sh
@@ -8,7 +8,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.2.0
+hiredis_version=1.3.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using GNU Make

--- a/examples/using_cmake_externalproject/CMakeLists.txt
+++ b/examples/using_cmake_externalproject/CMakeLists.txt
@@ -5,7 +5,7 @@ include(ExternalProject)
 ExternalProject_Add(hiredis
   PREFIX hiredis
   GIT_REPOSITORY  https://github.com/redis/hiredis
-  GIT_TAG         v1.2.0
+  GIT_TAG         v1.3.0
   CMAKE_ARGS
     "-DCMAKE_C_FLAGS:STRING=-std=c99"
     "-DENABLE_SSL:BOOL=ON"

--- a/examples/using_cmake_separate/build.sh
+++ b/examples/using_cmake_separate/build.sh
@@ -9,7 +9,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.2.0
+hiredis_version=1.3.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using CMake

--- a/examples/using_make/build.sh
+++ b/examples/using_make/build.sh
@@ -8,7 +8,7 @@ script_dir=$(realpath "${0%/*}")
 repo_dir=$(git rev-parse --show-toplevel)
 
 # Download hiredis
-hiredis_version=1.2.0
+hiredis_version=1.3.0
 curl -L https://github.com/redis/hiredis/archive/v${hiredis_version}.tar.gz | tar -xz -C ${script_dir}
 
 # Build and install downloaded hiredis using GNU Make


### PR DESCRIPTION
- Use latest release of hiredis (v1.3.0)
  This release of hiredis includes a CMakeLists.txt fix to support CMake 4.0.
  Fixes CI issues when Github runners have CMake 4.0.

Additional CI fixes:
- Use latest clang and CMake in CI
- Add Valkey 8.1 to compatibility test in CI  
    Update versions of each Valkey-branch that is tested.
- Remove prepare step in macOS CI since ninja already installed

